### PR TITLE
docs: rewrite AGENTS.md + add CONTRIBUTING.md and PR template (#4)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## What
+[1-2 sentence summary]
+
+## Why
+Closes #[issue number]
+
+## How
+[Approach taken, key design decisions]
+
+## Checklist
+- [ ] CI passes locally (ruff, pyright)
+- [ ] Specs updated (or N/A — no behavior change)
+- [ ] No lint/type suppressions added
+- [ ] No commented-out code, print statements, or TODOs without issue links
+- [ ] Commit messages follow `type(scope): description (#issue)` convention

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,81 +1,106 @@
 # AGENTS.md
 
-## Project Overview
-Durable interactive CLI chat built with PydanticAI + DBOS, with provider switch between Anthropic and OpenRouter.
+## Project
+Durable interactive CLI chat built with PydanticAI + DBOS, with provider switch
+between Anthropic and OpenRouter. Python 3.12+, `uv` only.
 
-- Runtime: Python 3.12+
-- Package manager: `uv` only
 - Entry point: `chat.py`
 - Backend integration: `pydantic-ai-backend==0.1.6` via `pydantic_ai_backends`
 
-## Setup Commands
+## Commands
+- Setup env: `cp .env.example .env`
+- Install: `uv sync`
+- Run: `uv run python chat.py`
+- Docker: `docker compose up --build` / `docker compose config`
+- Lint: `uv run ruff check path/to/file.py`
+- Lint all: `uv run ruff check .`
+- Format: `uv run ruff format path/to/file.py`
+- Typecheck: `uv run pyright path/to/file.py`
+- Compile check: `python3 -m py_compile chat.py`
+- No automated tests yet — do not claim tests passed.
 
-```bash
-cp .env.example .env
-uv sync
-```
+## Architecture
+Entry point: `chat.py` (single file)
 
-## Run Commands
+Project files:
+- `chat.py`: provider selection, env loading, backend toolset wiring, DBOS launch, interactive CLI
+- `pyproject.toml`: dependency source of truth
+- `uv.lock`: locked dependency graph
+- `docker-compose.yml`: interactive container runtime + DBOS volume
+- `Dockerfile`: uv-based image, non-root runtime
+- `.env.example`: required config template
+- `.vscode/launch.json`: local debug config using `.env`
 
-```bash
-uv run python chat.py
-docker compose up --build
-```
+Backend wiring pattern (do not deviate):
+- `AgentDeps` dataclass with `backend: LocalBackend`
+- `LocalBackend(root_dir=..., enable_execute=False)`
+- `create_console_toolset(include_execute=False, require_write_approval=True)`
+- `Agent(model, deps_type=AgentDeps, toolsets=[...])`
+- `dbos_agent.to_cli_sync(deps=AgentDeps(backend=backend))`
 
-## Validation Commands
+Runtime conventions:
+- Keep provider values explicit: `AI_PROVIDER=openrouter` or `AI_PROVIDER=anthropic`
+- Validate required keys with `required_env(...)` before use
+- Guard optional/runtime imports with fail-fast `SystemExit` messages recommending `uv sync`
+- `AI_PROVIDER=anthropic`: use model strings with `anthropic:` prefix
+- `AI_PROVIDER=openrouter`: use `OpenAIChatModel` + `OpenAIProvider(base_url="https://openrouter.ai/api/v1")`
+- Resolve `AGENT_WORKSPACE_ROOT` relative to `chat.py` when env value is not absolute
 
-```bash
-python3 -m py_compile chat.py
-docker compose config
-```
+Startup order (sequence matters):
+1. `load_dotenv(dotenv_path=Path(__file__).with_name(".env"))`
+2. Validate/build backend + toolsets + agent
+3. Configure DBOS
+4. `DBOS.launch()`
+5. Start CLI
 
-Notes:
-- There are no automated tests in this repo yet.
-- Do not claim tests passed.
+## Code Style
+- Strict typing (`pyright strict`), ruff enforced
+- Max file: 300 lines. Max function: 50 lines. Max complexity: 10.
+- No `# type: ignore`, no `# noqa`, no lint suppressions — fix the code
+- Comments explain WHY, never WHAT. No commented-out code.
+- No TODOs without issue numbers: `# TODO(#42): description`
+- One logical change per commit
+- Keep edits minimal and scoped to the request
+- Do not add dependencies without explicit user approval
+- Update `README.md` and `.env.example` whenever env vars or run commands change
 
-## Project Structure
+## Spec Rules (MANDATORY)
+- Every PR that changes behavior MUST update `specs/modules/`
+- New modules → new spec from `specs/_template.md`
+- Architectural decisions → ADR in `specs/decisions/`
+- Update `specs/OVERVIEW.md` if system-level architecture changes
+- Add changelog entry with date and PR/issue number
 
-```text
-chat.py               # Provider selection, env loading, backend toolset wiring, DBOS launch, interactive CLI
-pyproject.toml        # Dependency source of truth
-uv.lock               # Locked dependency graph
-docker-compose.yml    # Interactive container runtime + DBOS volume
-Dockerfile            # uv-based image, non-root runtime
-.env.example          # Required config template
-.vscode/launch.json   # Local debug config using .env
-```
+## Git Workflow
+- Branch from `main`: `{type}/issue-{number}-{slug}`
+- Types: feat, fix, chore, refactor, docs
+- Squash merge to `main` only — no direct pushes
+- Delete branch after merge
+- Commit format: `feat(chat): add provider caching (#42)`
 
-## Code Conventions
+## Security
+- Never commit secrets or tokens
+- `.env`, sqlite artifacts, caches, virtualenv must stay in `.gitignore`
+- Never log API keys or full auth headers
 
-- Keep provider values explicit: `AI_PROVIDER=openrouter` or `AI_PROVIDER=anthropic`.
-- Validate required keys with `required_env(...)` before use.
-- Guard optional/runtime imports with fail-fast `SystemExit` messages that recommend `uv sync`.
-- For OpenRouter use `OpenAIChatModel` + `OpenAIProvider(base_url="https://openrouter.ai/api/v1")`.
-- For Anthropic use model strings with `anthropic:` prefix.
-- Load env from repo-local file only:
-  - `load_dotenv(dotenv_path=Path(__file__).with_name(".env"))`
-- Backend wiring pattern:
-  - Define `AgentDeps` with `backend: LocalBackend`.
-  - Build backend with `LocalBackend(root_dir=..., enable_execute=False)`.
-  - Build toolset with `create_console_toolset(include_execute=False, require_write_approval=True)`.
-  - Pass `deps_type=AgentDeps` and `toolsets=[...]` when constructing `Agent`.
-  - Pass runtime deps to CLI via `dbos_agent.to_cli_sync(deps=AgentDeps(backend=backend))`.
-- Resolve `AGENT_WORKSPACE_ROOT` relative to `chat.py` when env value is not absolute.
-- Keep startup order:
-  1. load env
-  2. validate/build agent
-  3. configure DBOS
-  4. launch DBOS
-  5. start CLI
-
-## Security Rules
-
-- Never commit secrets or tokens.
-- `.env`, sqlite artifacts, caches, and virtualenv must stay ignored.
-- Never log API keys or full auth headers.
-
-## Change Rules
-
-- Keep edits minimal and scoped to the request.
-- Do not add dependencies without explicit user approval.
-- Update `README.md` and `.env.example` whenever env vars or run commands change.
+## Anti-Patterns (instant PR rejection)
+1. Lint/type suppressions (`# type: ignore`, `# noqa`, `# pyright: ignore`)
+2. Weakening lint rules to pass CI
+3. Files >300 lines
+4. Functions >50 lines
+5. Dead code (commented-out blocks, unused imports/vars)
+6. TODOs without issue links
+7. Bare except (`except:` or `except Exception:` without specific handling)
+8. Hardcoded secrets, API keys, or environment-specific values
+9. Bare `print()` for debugging — use `logging` module (`print()` is acceptable only in CLI entry point output via DBOS CLI mechanism)
+10. Untyped function parameters or return values
+11. Magic numbers without named constants
+12. Adding dependencies for trivial functionality
+13. Mixing concerns (feature + refactor + fix in same PR)
+14. Swallowed errors (`except: pass`)
+15. Copy-paste duplication
+16. Overly clever code (nested ternaries, complex comprehensions)
+17. Missing docstrings on public functions/classes
+18. Test files without assertions
+19. Changing files outside the scope of the issue
+20. Missing error context (`raise ValueError("failed")` — describe what/why)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to Autopoiesis
+
+## For AI Agents
+Read `AGENTS.md` first; it contains project-specific instructions that override
+general knowledge.
+
+## Workflow
+1. Pick up an issue (or get assigned one)
+2. Create branch: `{type}/issue-{number}-{slug}` from `main`
+3. Implement. Update specs. Run all checks locally.
+4. Open PR to `main` using the PR template
+5. Address review feedback and iterate until approved
+6. Never merge your own PR
+
+## PR Requirements
+- All CI checks pass (lint, typecheck, spec sync)
+- Spec files updated if behavior changed
+- One logical concern per PR
+- 50-200 lines changed ideal, 400 max
+
+## Who Reviews
+- AI agents review each other's PRs
+- David has final approval on `main`
+- Reviewers check code quality, spec alignment, test coverage, and anti-patterns
+
+## What Gets Rejected
+See Anti-Patterns in `AGENTS.md`.


### PR DESCRIPTION
## What
Rewrites AGENTS.md to <150 lines, adds CONTRIBUTING.md and PR template.

## Why
Closes #4

## How
- Restructured AGENTS.md preserving all content (backend wiring, Docker, security)
- Added CONTRIBUTING.md for human-readable guidelines
- Added .github/pull_request_template.md with 5 checkboxes

## Checklist
- [x] AGENTS.md under 150 lines (106)
- [x] Specs updated (N/A — no behavior change)
- [x] No lint/type suppressions added
- [x] No commented-out code, print statements, or TODOs without issue links
- [x] Commit messages follow convention