### PR TITLE
docs: create specs/ directory with living documentation system (#2)

### DIFF
--- a/specs/OVERVIEW.md
+++ b/specs/OVERVIEW.md
@@ -1,0 +1,44 @@
+# Autopoiesis Overview
+
+Autopoiesis is a durable interactive CLI chat application built around a PydanticAI agent. The app is designed for local-first development with explicit environment configuration and predictable startup behavior.
+
+The runtime combines model-facing agent logic with durable execution so conversations can run through a DBOS-managed lifecycle. Provider selection is abstracted behind configuration so the same CLI entrypoint can target either Anthropic or OpenRouter.
+
+## Architecture
+
+- **PydanticAI agent** handles model orchestration, deps typing, and tool wiring.
+- **DBOS durability layer** wraps agent execution and provides launch/runtime lifecycle management.
+- **Provider abstraction** selects Anthropic or OpenRouter at startup without changing call sites.
+- **Backend tool integration** uses `LocalBackend` and the console toolset for file operations inside a scoped workspace.
+
+## Key Concepts
+
+- **`AgentDeps`** carries runtime dependencies for each turn; currently a `LocalBackend`.
+- **`LocalBackend`** provides file operations with shell execution disabled.
+- **Console toolset** is created with `include_execute=False` and `require_write_approval=True`.
+- **Provider switching** is controlled by `AI_PROVIDER` (`anthropic` or `openrouter`).
+- **Fail-fast env validation** uses `required_env(...)` to raise `SystemExit` on missing required keys.
+
+## Data Flow
+
+1. `.env`
+2. `load_dotenv(dotenv_path=Path(__file__).with_name(".env"))`
+3. `os.getenv(...)` reads env vars
+4. `build_backend()` / `build_toolsets()` / `build_agent(...)`
+5. `DBOS(config=dbos_config)`
+6. `DBOS.launch()`
+7. `dbos_agent.to_cli_sync(deps=AgentDeps(backend=backend))`
+
+## Development Workflow
+
+- Trunk-based development with `main` as the integration branch.
+- Short-lived branches (or worktrees) for focused changes.
+- Open PRs against `main`.
+- Squash merge to keep history linear and reduce merge noise.
+
+For workflow rationale, see `specs/decisions/001-trunk-based-workflow.md`.
+
+## Module Index
+
+- `chat.py`: `specs/modules/chat.md`
+

--- a/specs/_template.md
+++ b/specs/_template.md
@@ -1,0 +1,30 @@
+# Module: [Name]
+
+## Purpose
+[1-2 sentences]
+
+## Status
+- **Last updated:** YYYY-MM-DD (PR #X)
+- **Source:** [file/directory path]
+
+## Key Concepts
+- **[Concept]** - [explanation]
+
+## Architecture
+[Key files, data flow, integration points]
+
+## API Surface
+[Endpoints, env vars, CLI commands - whatever is externally visible]
+
+## Functions
+[Public functions with signatures and non-obvious behavior]
+
+## Invariants & Rules
+[Things that must always be true]
+
+## Dependencies
+[External packages as listed in pyproject.toml, internal modules]
+
+## Change Log
+- YYYY-MM-DD: [description] (PR #X)
+

--- a/specs/decisions/001-trunk-based-workflow.md
+++ b/specs/decisions/001-trunk-based-workflow.md
@@ -1,0 +1,31 @@
+# ADR-001: Trunk-Based Workflow
+
+**Date:** 2026-02-15
+**Status:** Accepted
+
+## Context
+
+The project needed a clear collaboration model for fast iteration with human and agent contributors. In Issue #1, the team evaluated branch strategy, merge policy, and how to parallelize changes safely without long-lived integration branches.
+
+For full background and rationale details, see GitHub Issue #1.
+
+## Decision
+
+- Use trunk-based development with `main` as the single integration branch.
+- Drop the separate `dev` branch workflow.
+- Keep feature branches short-lived and scoped to one change.
+- Open PRs against `main` and use squash merge.
+- Use git worktrees when running parallel agent efforts so each task has isolated filesystem state.
+
+## Consequences
+
+Positive:
+- Faster integration cadence and less branch divergence.
+- Simpler release path because `main` is always the source of truth.
+- Cleaner history from squash merges.
+- Worktrees reduce context collisions for concurrent contributors.
+
+Tradeoffs:
+- Requires tighter PR review discipline because integration happens continuously.
+- Large or long-running efforts must be split into smaller PRs to avoid rebasing pain.
+

--- a/specs/decisions/002-spec-as-code.md
+++ b/specs/decisions/002-spec-as-code.md
@@ -1,0 +1,27 @@
+# ADR-002: Specs as Code
+
+**Date:** 2026-02-15
+**Status:** Accepted
+
+## Context
+
+The project needed durable, reviewable technical documentation that stays synchronized with implementation changes. External documentation platforms create drift because updates are detached from code review and merge workflows.
+
+## Decision
+
+- Keep specs in-repo as Markdown under `specs/`.
+- Require spec updates in the same PR whenever behavior changes.
+- Enforce synchronization with CI checks (issue #3) using repository diffs.
+- Treat missing spec updates for behavioral changes as an incomplete PR.
+
+## Consequences
+
+Positive:
+- Documentation changes are reviewed with code in one place.
+- Specs are versioned, diffable, and easy for both humans and LLMs to consume.
+- CI can enforce the policy without external tooling dependencies.
+
+Tradeoffs:
+- Contributors must budget time for spec maintenance on each behavior change.
+- Reviewers must enforce doc quality, not just code correctness.
+

--- a/specs/modules/chat.md
+++ b/specs/modules/chat.md
@@ -1,0 +1,114 @@
+# Module: chat.py
+
+## Purpose
+
+`chat.py` is the runtime entrypoint for the durable interactive CLI chat app. It loads configuration, builds a provider-specific PydanticAI agent with a local backend toolset, initializes DBOS, and starts the CLI loop.
+
+## Status
+
+- **Last updated:** 2026-02-15 (PR #2)
+- **Source:** `chat.py`
+
+## API Surface
+
+### Environment Variables
+
+| Env Var | Required | Default | Source in code | Description |
+|---|---|---|---|---|
+| `AI_PROVIDER` | No | `anthropic` | `main()` | Provider selection (`anthropic` or `openrouter`) |
+| `ANTHROPIC_API_KEY` | If `AI_PROVIDER=anthropic` | - | `build_agent()` via `required_env()` | Anthropic API key |
+| `ANTHROPIC_MODEL` | No | `anthropic:claude-3-5-sonnet-latest` | `build_agent()` via `os.getenv()` | Anthropic model string |
+| `OPENROUTER_API_KEY` | If `AI_PROVIDER=openrouter` | - | `build_agent()` via `required_env()` | OpenRouter API key |
+| `OPENROUTER_MODEL` | No | `openai/gpt-4o-mini` | `build_agent()` via `os.getenv()` | OpenRouter model string |
+| `AGENT_WORKSPACE_ROOT` | No | `data/agent-workspace` | `resolve_workspace_root()` | Agent file access root (relative to `chat.py` when not absolute) |
+| `DBOS_APP_NAME` | No | `pydantic_dbos_agent` | `main()` | DBOS application name |
+| `DBOS_AGENT_NAME` | No | `chat` | `main()` | Agent/CLI name |
+| `DBOS_SYSTEM_DATABASE_URL` | No | `sqlite:///dbostest.sqlite` | `main()` | DBOS database connection |
+
+## Functions
+
+### `required_env(name: str) -> str`
+
+- Reads an env var and returns its value when present.
+- Raises `SystemExit` with a clear message when missing.
+- Intentionally fail-fast at startup; does not raise `KeyError`.
+
+### `resolve_workspace_root() -> Path`
+
+- Reads `AGENT_WORKSPACE_ROOT` with default `data/agent-workspace`.
+- Resolves relative paths against `Path(__file__).resolve().parent`, not CWD.
+- Creates the directory with `mkdir(parents=True, exist_ok=True)` before returning.
+
+### `build_backend() -> LocalBackend`
+
+- Builds `LocalBackend(root_dir=resolve_workspace_root(), enable_execute=False)`.
+- Keeps shell execution disabled for the backend.
+
+### `validate_console_deps_contract() -> None`
+
+- Runtime compatibility check for the console toolset dependency contract.
+- Verifies `AgentDeps.backend` annotation is exactly `LocalBackend`.
+- Verifies `LocalBackend` exposes callable methods:
+  `ls_info`, `read`, `write`, `edit`, `glob_info`, `grep_raw`.
+- Exits with `SystemExit` if the structural contract is broken.
+
+### `build_toolsets() -> list[AbstractToolset[AgentDeps]]`
+
+- Calls `validate_console_deps_contract()` first.
+- Creates one console toolset via
+  `create_console_toolset(include_execute=False, require_write_approval=True)`.
+- Uses an intentional `cast(...)` because the factory is typed for protocol deps,
+  while `AgentDeps` satisfies that protocol structurally through `backend: LocalBackend`.
+
+### `build_agent(provider: str, agent_name: str, toolsets: list[AbstractToolset[AgentDeps]]) -> Agent[AgentDeps, str]`
+
+- Provider factory with explicit parameters for provider, name, and toolsets.
+- Does provider branching only from the `provider` argument (selection is done in `main()`).
+- `anthropic` branch:
+  - requires `ANTHROPIC_API_KEY` via `required_env()`
+  - uses model from `ANTHROPIC_MODEL` defaulting to `anthropic:claude-3-5-sonnet-latest`
+- `openrouter` branch:
+  - builds `OpenAIChatModel`
+  - uses `OpenAIProvider(base_url="https://openrouter.ai/api/v1", api_key=required_env("OPENROUTER_API_KEY"))`
+  - reads model from `OPENROUTER_MODEL` defaulting to `openai/gpt-4o-mini`
+- Unknown provider raises `SystemExit`.
+
+### `main() -> None`
+
+- Startup sequence is ordered and intentional:
+  1. `load_dotenv(dotenv_path=Path(__file__).with_name(".env"))`
+  2. Read `AI_PROVIDER` and `DBOS_AGENT_NAME` from env
+  3. `build_backend()`
+  4. `build_toolsets()`
+  5. `build_agent(provider, agent_name, toolsets)`
+  6. `DBOS(config=dbos_config)` (defaults include SQLite URL)
+  7. `DBOSAgent(agent, name=agent_name)`
+  8. `DBOS.launch()`
+  9. `dbos_agent.to_cli_sync(deps=AgentDeps(backend=backend))`
+
+## Invariants & Rules
+
+- Required env vars fail fast with `SystemExit`, not `KeyError`.
+- `.env` loads from a path relative to `chat.py` (`Path(__file__).with_name(".env")`), not CWD.
+- Workspace root resolves relative to `chat.py` when not absolute.
+- Workspace directory is auto-created on startup.
+- Backend execute is always disabled (`enable_execute=False`).
+- Write approval is always required (`require_write_approval=True`).
+- Console deps contract is validated at startup (`validate_console_deps_contract()`).
+- `build_toolsets()` uses intentional `cast()` because `AgentDeps` satisfies the console deps protocol structurally via `backend: LocalBackend`.
+- DBOS defaults to SQLite (`sqlite:///dbostest.sqlite`), which is appropriate for development and typically replaced in production.
+
+## Dependencies
+
+- `pydantic-ai-slim[openai,anthropic,cli,dbos,mcp]>=1.59,<2` - core agent framework with provider, CLI, and DBOS extras.
+- `pydantic-ai-backend==0.1.6` - `LocalBackend` and console toolset integration.
+- `python-dotenv>=1.2,<2` - `.env` loading.
+
+Notes:
+- `dbos` is consumed via the `dbos` extra on `pydantic-ai-slim`, not as a direct top-level dependency entry.
+- The `mcp` extra is present in `pyproject.toml` but not currently used directly in `chat.py`.
+
+## Change Log
+
+- 2026-02-15: Added living module spec synced to current `chat.py` implementation, including env vars, startup order, and structural typing contract details. (PR #2)
+


### PR DESCRIPTION
## What
Creates specs/ directory with living documentation and adds docstrings to chat.py.

## Why
Closes #2

## How
- Created specs/OVERVIEW.md, specs/modules/chat.md, specs/_template.md
- Created ADRs: 001-trunk-based-workflow, 002-spec-as-code
- Added WHY-focused docstrings to all 7 functions + AgentDeps + module
- specs/modules/chat.md verified against actual chat.py code

## Checklist
- [x] CI passes locally (ruff, pyright)
- [x] Specs updated (this IS the spec creation)
- [x] No lint/type suppressions added
- [x] No commented-out code, print statements, or TODOs without issue links
- [x] Commit messages follow convention