### PR TITLE
ci: add GitHub Actions for linting, type checking, and spec sync (#3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - run: uv sync
+      - name: Ruff lint
+        run: uv run ruff check . --output-format=github
+      - name: Ruff format check
+        run: uv run ruff format --check .
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - run: uv sync
+      - name: Pyright
+        run: uv run pyright
+
+  spec-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check spec freshness
+        run: |
+          # Only run if specs/ directory exists (created in issue #2)
+          if [ ! -d "specs" ]; then
+            echo "specs/ directory not found -- skipping check"
+            exit 0
+          fi
+          SRC_CHANGED=$(git diff --name-only origin/main...HEAD -- '*.py' | wc -l)
+          SPEC_CHANGED=$(git diff --name-only origin/main...HEAD -- 'specs/' | wc -l)
+          if [ "$SRC_CHANGED" -gt 0 ] && [ "$SPEC_CHANGED" -eq 0 ]; then
+            echo "::error::Python source changed but no spec files were updated. If this PR changes behavior, update the relevant spec."
+            exit 1
+          fi

--- a/chat.py
+++ b/chat.py
@@ -1,20 +1,19 @@
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
 
+from dotenv import load_dotenv
 from pydantic_ai import AbstractToolset, Agent
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
-from dotenv import load_dotenv
-
 
 try:
     from dbos import DBOS, DBOSConfig
     from pydantic_ai.durable_exec.dbos import DBOSAgent
 except ModuleNotFoundError as exc:
     raise SystemExit(
-        "Missing DBOS dependencies. Run `uv sync` so `pydantic-ai-slim[dbos,mcp]` and `dbos` are installed."
+        "Missing DBOS dependencies. Run `uv sync` so "
+        "`pydantic-ai-slim[dbos,mcp]` and `dbos` are installed."
     ) from exc
 
 try:
@@ -54,23 +53,32 @@ def validate_console_deps_contract() -> None:
     backend_annotation = AgentDeps.__annotations__.get("backend")
     if backend_annotation is not LocalBackend:
         raise SystemExit(
-            "AgentDeps.backend must be typed as LocalBackend to satisfy console toolset dependency expectations."
+            "AgentDeps.backend must be typed as LocalBackend to satisfy "
+            "console toolset dependency expectations."
         )
 
-    required_backend_methods = ("ls_info", "read", "write", "edit", "glob_info", "grep_raw")
-    missing = [name for name in required_backend_methods if not callable(getattr(LocalBackend, name, None))]
+    required_backend_methods = (
+        "ls_info",
+        "read",
+        "write",
+        "edit",
+        "glob_info",
+        "grep_raw",
+    )
+    missing = [
+        name for name in required_backend_methods if not callable(getattr(LocalBackend, name, None))
+    ]
     if missing:
         raise SystemExit(
-            "LocalBackend is missing required console backend methods: " + ", ".join(sorted(missing))
+            "LocalBackend is missing required console backend methods: "
+            + ", ".join(sorted(missing))
         )
 
 
 def build_toolsets() -> list[AbstractToolset[AgentDeps]]:
     validate_console_deps_contract()
     toolset = create_console_toolset(include_execute=False, require_write_approval=True)
-    # `create_console_toolset` returns FunctionToolset[ConsoleDeps]. This cast is intentional:
-    # AgentDeps satisfies that protocol structurally via `backend: LocalBackend`.
-    return cast(list[AbstractToolset[AgentDeps]], [toolset])
+    return [toolset]
 
 
 def build_agent(
@@ -108,7 +116,10 @@ def main() -> None:
 
     dbos_config: DBOSConfig = {
         "name": os.getenv("DBOS_APP_NAME", "pydantic_dbos_agent"),
-        "system_database_url": os.getenv("DBOS_SYSTEM_DATABASE_URL", "sqlite:///dbostest.sqlite"),
+        "system_database_url": os.getenv(
+            "DBOS_SYSTEM_DATABASE_URL",
+            "sqlite:///dbostest.sqlite",
+        ),
     }
     DBOS(config=dbos_config)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,48 @@
 [project]
 name = "autopoiesis"
 version = "0.1.0"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
   "pydantic-ai-slim[openai,anthropic,cli,dbos,mcp]>=1.59,<2",
   "pydantic-ai-backend==0.1.6",
   "python-dotenv>=1.2,<2",
 ]
+
+[dependency-groups]
+dev = [
+  "ruff>=0.9",
+  "pyright>=1.1",
+]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+  "E",    # pycodestyle errors
+  "W",    # pycodestyle warnings
+  "F",    # pyflakes
+  "I",    # isort
+  "N",    # pep8-naming
+  "UP",   # pyupgrade
+  "B",    # flake8-bugbear
+  "C4",   # flake8-comprehensions
+  "SIM",  # flake8-simplify
+  "RUF",  # ruff-specific
+  "PLR",  # pylint refactor (includes function length)
+  "C901", # complexity
+]
+ignore = []
+
+[tool.ruff.lint.pylint]
+max-args = 6
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.pyright]
+include = ["."]
+typeCheckingMode = "strict"
+pythonVersion = "3.12"
+reportMissingTypeStubs = false


### PR DESCRIPTION
## Summary
Adds CI pipeline via GitHub Actions with three jobs: ruff lint/format, pyright strict type checking, and spec freshness check.

## Changes
- `.github/workflows/ci.yml` — lint, typecheck, spec-check jobs on PRs to main
- `pyproject.toml` — ruff + pyright config, dependency-groups, requires-python bumped to >=3.12
- `chat.py` — fixed import sorting, long lines, removed unnecessary `cast()`

## Checklist
- [x] CI workflow runs on PRs to main
- [x] Ruff passes clean (no suppressions)
- [x] Spec-check handles missing specs/ gracefully
- [x] pyproject.toml has consolidated ruff + pyright config
- [x] No `# noqa` or `# type: ignore` added

Closes #3