### PR TITLE
fix: rich model-facing tool descriptions for all agent tools

### DIFF
--- a/memory_tools.py
+++ b/memory_tools.py
@@ -38,7 +38,19 @@ def create_memory_toolset(
         query: str,
         max_results: int = 5,
     ) -> str:
-        """Search persistent memory (database + files) for past context."""
+        """Search past conversations and memory files for relevant context.
+
+        When to use: Before answering questions about prior work, decisions, preferences,
+        or anything that might have been discussed in previous sessions. Also use when
+        the user references something you don't have in current context.
+        Returns: Ranked list of matching memory entries and file snippets with timestamps.
+        Related: memory_save (to persist new knowledge), memory_get (to read full file content).
+
+        Args:
+            query: Natural language search query. FTS5 full-text search — use key terms
+                rather than full sentences for best results.
+            max_results: Number of results to return. Default 5.
+        """
         return combined_search(db_path, workspace_root, query, max_results)
 
     @toolset.tool
@@ -48,7 +60,18 @@ def create_memory_toolset(
         from_line: int | None = None,
         lines: int | None = None,
     ) -> str:
-        """Read a snippet from a workspace memory file."""
+        """Read lines from a memory file (MEMORY.md or memory/YYYY-MM-DD.md).
+
+        When to use: After memory_search returns a file match and you need the full
+        content, or when loading specific sections of long-term memory at session start.
+        Returns: The requested lines from the file, or an error if the path is outside workspace.
+        Related: memory_search (find relevant files first), memory_save (persist new entries).
+
+        Args:
+            path: Relative path within workspace (e.g., "MEMORY.md", "memory/2026-02-16.md").
+            from_line: Starting line number (1-indexed). Omit to start from beginning.
+            lines: Number of lines to read. Omit to read entire file.
+        """
         return get_memory_file_snippet(workspace_root, path, from_line, lines)
 
     @toolset.tool
@@ -57,7 +80,20 @@ def create_memory_toolset(
         summary: str,
         topics: list[str],
     ) -> str:
-        """Save a memory entry for future retrieval."""
+        """Persist a piece of knowledge to the memory database for future sessions.
+
+        When to use: When you learn something important that should survive across sessions —
+        key decisions, user preferences, project context, lessons learned. Don't save
+        routine or easily re-fetched information.
+        Returns: Confirmation message with the new memory entry ID.
+        Related: memory_search (retrieve saved memories later), memory_get (read memory files).
+
+        Args:
+            summary: The content to remember. Write it as a clear, self-contained statement
+                that future-you can understand without additional context.
+            topics: List of topic tags for categorization and search (e.g., ["project-x",
+                "architecture", "decision"]). Use consistent, lowercase tag names.
+        """
         entry_id = save_memory(db_path, summary, topics)
         return f"Memory saved (id: {entry_id})."
 

--- a/process_tool.py
+++ b/process_tool.py
@@ -35,7 +35,14 @@ def _require_session(session_id: str) -> exec_registry.ProcessSession:
 async def process_list(
     ctx: RunContext[AgentDeps],
 ) -> list[dict[str, Any]]:
-    """List all tracked process sessions."""
+    """List all tracked process sessions (running and exited).
+
+    When to use: To check what background processes are active, find session IDs
+    for polling or interaction, or verify a process has started.
+    Returns: List of dicts, each with session_id, command, pid, exit_code (null if
+    still running), and background flag.
+    Related: process_poll (check one session in detail), execute (start new process).
+    """
     return [_session_info(s) for s in exec_registry.list_sessions()]
 
 
@@ -43,7 +50,16 @@ async def process_poll(
     ctx: RunContext[AgentDeps],
     session_id: str,
 ) -> dict[str, Any]:
-    """Poll a session for its current status and output tail."""
+    """Check a specific session's current status and recent output.
+
+    When to use: After starting a background process, to check if it has finished
+    and see its latest output. Lighter than process_log when you just need a status check.
+    Returns: Session info dict plus output_tail (last 5 lines of output).
+    Related: process_log (read full output with pagination), process_list (find session IDs).
+
+    Args:
+        session_id: The session ID returned by execute or execute_pty.
+    """
     session = _require_session(session_id)
     code = session.process.returncode
     if code is not None and session.exit_code is None:
@@ -59,7 +75,18 @@ async def process_log(
     offset: int = 0,
     limit: int = 50,
 ) -> dict[str, Any]:
-    """Read log lines from a session's output file."""
+    """Read log lines from a session's output file with pagination.
+
+    When to use: When process_poll's 5-line tail isn't enough and you need to see
+    more output — full build logs, error tracebacks, test results, etc.
+    Returns: Dict with session_id, lines (list of strings), and total line count.
+    Related: process_poll (quick status + tail), execute (start process).
+
+    Args:
+        session_id: The session ID to read logs from.
+        offset: Line number to start reading from (0-indexed). Default 0.
+        limit: Maximum number of lines to return. Default 50.
+    """
     session = _require_session(session_id)
     try:
         text = session.log_path.read_text(errors="replace")
@@ -75,7 +102,17 @@ async def process_write(
     session_id: str,
     data: str,
 ) -> dict[str, str]:
-    """Write data to a session's stdin."""
+    """Write data to a non-PTY session's stdin pipe.
+
+    When to use: To send input to a running subprocess that reads from stdin (e.g.,
+    answering a prompt, piping data). For PTY sessions, use process_send_keys instead.
+    Returns: Confirmation dict with status and session_id.
+    Related: process_send_keys (for PTY sessions), execute (start non-PTY process).
+
+    Args:
+        session_id: The session to write to.
+        data: String data to write to stdin. Include '\\n' for newlines/Enter.
+    """
     session = _require_session(session_id)
     if session.process.stdin is None:
         msg = "Session has no stdin (PTY sessions use send_keys)"
@@ -90,7 +127,20 @@ async def process_send_keys(
     session_id: str,
     data: str,
 ) -> dict[str, str]:
-    """Send keystrokes to a PTY session's master fd."""
+    """Send keystrokes to a PTY session (interactive terminal input).
+
+    When to use: To type into an interactive PTY session — answering prompts, sending
+    commands to a REPL, navigating terminal UIs. Only works with sessions started via
+    execute_pty. For non-PTY sessions, use process_write instead.
+    Returns: Confirmation dict with status and session_id.
+    Related: process_write (for non-PTY stdin), execute_pty (start PTY session),
+    process_log (read what the PTY printed back).
+
+    Args:
+        session_id: The PTY session to send keystrokes to.
+        data: Keystrokes as a string. Use '\\r' for Enter, '\\x03' for Ctrl-C,
+            '\\x04' for Ctrl-D, '\\x1b' for Escape.
+    """
     session = _require_session(session_id)
     if session.master_fd is None or session.master_fd < 0:
         msg = "Session has no PTY master fd"
@@ -105,7 +155,18 @@ async def process_kill(
     *,
     sig: int = signal.SIGTERM,
 ) -> dict[str, Any]:
-    """Kill a running session."""
+    """Terminate a running process session.
+
+    When to use: To stop a background process that is no longer needed, hung, or
+    misbehaving. Also useful for cleaning up servers or watchers after testing.
+    Returns: Dict with status ('killed' or 'already_exited') and session info.
+    Related: process_list (find sessions to kill), execute (start new process).
+
+    Args:
+        session_id: The session to terminate.
+        sig: Unix signal number to send. Default SIGTERM (15) for graceful shutdown.
+            Use 9 (SIGKILL) for force-kill of unresponsive processes.
+    """
     session = _require_session(session_id)
     if session.exit_code is not None:
         return {"status": "already_exited", **_session_info(session)}

--- a/skills.py
+++ b/skills.py
@@ -267,12 +267,30 @@ def create_skills_toolset(
 
     @toolset.tool
     async def list_skills(ctx: RunContext[AgentDeps]) -> str:
-        """List available skills with name, description, and tags."""
+        """List all available skills with their name, version, description, and tags.
+
+        When to use: To discover what skills are available before loading one. Call this
+        first when you need a capability you don't have in your base toolset, or when the
+        user asks about available skills.
+        Returns: Formatted list of skills with name, version, description, and tags.
+        Related: load_skill (get full instructions for a specific skill).
+        """
         return _format_skill_list(cache)
 
     @toolset.tool
     async def load_skill(ctx: RunContext[AgentDeps], skill_name: str) -> str:
-        """Load full instructions for a skill by name (progressive disclosure)."""
+        """Load full instructions for a skill, enabling you to use its capabilities.
+
+        When to use: After identifying a relevant skill via list_skills. Loading a skill
+        gives you detailed instructions on how to perform that skill's task — protocols,
+        formats, APIs, workflows. Load before attempting the skill's domain.
+        Returns: Full markdown instructions from the skill's SKILL.md file.
+        Related: list_skills (discover available skills), read_skill_resource (access
+        supporting files like templates or configs).
+
+        Args:
+            skill_name: Exact skill name as shown by list_skills (case-sensitive).
+        """
         return _load_skill_instructions(cache, skill_name)
 
     @toolset.tool
@@ -281,17 +299,51 @@ def create_skills_toolset(
         skill_name: str,
         resource_name: str,
     ) -> str:
-        """Read a resource file from a skill directory."""
+        """Read a supporting resource file bundled with a skill.
+
+        When to use: When a skill's instructions reference additional files — templates,
+        config examples, schemas, or sample data. The skill's resource list is shown in
+        list_skills output.
+        Returns: The file content as text, or an error if the resource doesn't exist or
+        the path escapes the skill directory.
+        Related: load_skill (get instructions that reference these resources),
+        list_skills (see which resources each skill has).
+
+        Args:
+            skill_name: The skill that owns the resource (case-sensitive).
+            resource_name: Filename relative to the skill directory (e.g., "template.md",
+                "config.yaml"). Must be a listed resource — no path traversal allowed.
+        """
         return _read_resource(cache, skill_name, resource_name)
 
     @toolset.tool
     async def validate_skill(ctx: RunContext[AgentDeps], skill_name: str) -> str:
-        """Validate SKILL.md frontmatter and required structure."""
+        """Validate a skill's SKILL.md frontmatter and required structure.
+
+        When to use: After creating or editing a skill definition. Checks that
+        frontmatter has all required fields, types are correct, and structure follows
+        the skill specification. Run before committing skill changes.
+        Returns: Validation result — either "valid" or a list of specific errors.
+        Related: lint_skill (style checks), load_skill (test that instructions load).
+
+        Args:
+            skill_name: The skill to validate (case-sensitive, must be discovered).
+        """
         return _validate_skill(cache, skill_name)
 
     @toolset.tool
     async def lint_skill(ctx: RunContext[AgentDeps], skill_name: str) -> str:
-        """Lint SKILL.md for common style issues."""
+        """Lint a skill's SKILL.md instructions for common style issues.
+
+        When to use: After creating or editing a skill to catch style problems —
+        missing sections, unclear instructions, formatting issues. Complements
+        validate_skill which checks structure; this checks quality.
+        Returns: List of style warnings/suggestions, or confirmation that no issues found.
+        Related: validate_skill (structural validation), load_skill (preview instructions).
+
+        Args:
+            skill_name: The skill to lint (case-sensitive, must be discovered).
+        """
         return _lint_skill(cache, skill_name)
 
     # Ensure pyright recognizes decorator-registered functions as used


### PR DESCRIPTION
Rewrites all tool docstrings to be model-facing: when to use, what it returns, related tools, parameter guidance. The LLM reads these as tool descriptions — they need to teach it when and how to use each tool.

## Tools updated (14 total)

### exec_tool.py
- `execute` — run shell commands (non-interactive)
- `execute_pty` — run shell commands under PTY (interactive)

### process_tool.py
- `process_list` — list all tracked sessions
- `process_poll` — check session status + output tail
- `process_log` — read full output with pagination
- `process_write` — write to non-PTY stdin
- `process_send_keys` — send keystrokes to PTY session
- `process_kill` — terminate a session

### memory_tools.py
- `memory_search` — FTS5 search over memory DB + files
- `memory_get` — read memory file lines
- `memory_save` — persist knowledge to memory DB

### skills.py
- `list_skills` — discover available skills
- `load_skill` — load full skill instructions
- `read_skill_resource` — read skill resource files
- `validate_skill` — structural validation of SKILL.md
- `lint_skill` — style checks on SKILL.md

## Quality
- `ruff check` ✅
- `ruff format --check` ✅
- `pyright` ✅ (0 errors)
- `pytest` ✅ (47 passed)