### PR TITLE
fix(exec): use Path.is_relative_to for sandbox confinement (#42)

### DIFF
--- a/exec_tool.py
+++ b/exec_tool.py
@@ -53,7 +53,7 @@ def sandbox_cwd(cwd: str | None, workspace_root: Path) -> str:
     if cwd is None:
         return str(workspace_root)
     resolved = (workspace_root / cwd).resolve()
-    if not str(resolved).startswith(str(workspace_root.resolve())):
+    if not resolved.is_relative_to(workspace_root.resolve()):
         msg = f"Working directory escapes workspace: {cwd}"
         raise ValueError(msg)
     return str(resolved)

--- a/specs/modules/exec.md
+++ b/specs/modules/exec.md
@@ -54,6 +54,11 @@ Uses stdlib `pty.openpty()` — zero external dependencies. Enables interactive 
 - `execute` and `execute_pty` return `ToolReturn` (not raw dicts) with structured metadata (`session_id`, `log_path`, `exit_code`).
 - `process_log` returns `ToolReturn` with log content as `return_value` and metadata (`session_id`, `log_path`, `total` line count).
 
+## Change Log
+
+- 2026-02-16: Fixed `sandbox_cwd` path confinement to use `Path.is_relative_to()`
+  instead of string prefix matching, preventing sibling-directory escape. (Issue #42)
+
 ## References
 
 - Issue: #24

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -113,6 +113,15 @@ def testsandbox_cwd_rejects_traversal(workspace: Path) -> None:
         sandbox_cwd("../../etc", workspace)
 
 
+def testsandbox_cwd_rejects_sibling_prefix_escape(workspace: Path) -> None:
+    root = workspace / "work"
+    root.mkdir()
+    sibling = workspace / "work-escape"
+    sibling.mkdir()
+    with pytest.raises(ValueError, match="escapes workspace"):
+        sandbox_cwd("../work-escape", root)
+
+
 def testsandbox_cwd_allows_subdir(workspace: Path) -> None:
     sub = workspace / "sub"
     sub.mkdir()


### PR DESCRIPTION
## Summary
Replaces string prefix matching (`str.startswith`) in `sandbox_cwd` with `Path.is_relative_to()` to prevent sibling-directory escape (e.g. `/data/workspace-evil` passing check for `/data/workspace`).

## Changes
- `exec_tool.py`: 1-line fix — `startswith` → `is_relative_to`
- `tests/test_exec.py`: Regression test for sibling-prefix attack vector

## Closes #42