### PR TITLE
fix(db): close SQLite connections properly + enable WAL mode (#44)

### DIFF
--- a/history_store.py
+++ b/history_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+from contextlib import closing
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -39,7 +40,8 @@ def resolve_history_db_path(dbos_db_url: str) -> str:
 def init_history_store(db_path: str) -> None:
     """Create the checkpoint table if it does not already exist."""
     _ensure_parent_dir(db_path)
-    with sqlite3.connect(db_path) as conn:
+    with closing(sqlite3.connect(db_path)) as conn, conn:
+        conn.execute("PRAGMA journal_mode=WAL")
         conn.execute(_CREATE_TABLE_SQL)
         conn.commit()
 
@@ -48,7 +50,8 @@ def save_checkpoint(db_path: str, work_item_id: str, history_json: str, round_co
     """Upsert a checkpoint row for one work item id."""
     _ensure_parent_dir(db_path)
     now = datetime.now(UTC).isoformat()
-    with sqlite3.connect(db_path) as conn:
+    with closing(sqlite3.connect(db_path)) as conn, conn:
+        conn.execute("PRAGMA journal_mode=WAL")
         conn.execute(
             """
             INSERT INTO agent_history_checkpoints (
@@ -76,7 +79,8 @@ def load_checkpoint(db_path: str, work_item_id: str) -> str | None:
     is stale compared to this process.
     """
     _ensure_parent_dir(db_path)
-    with sqlite3.connect(db_path) as conn:
+    with closing(sqlite3.connect(db_path)) as conn, conn:
+        conn.execute("PRAGMA journal_mode=WAL")
         row = conn.execute(
             """
             SELECT history_json, checkpoint_version
@@ -96,7 +100,8 @@ def load_checkpoint(db_path: str, work_item_id: str) -> str | None:
 def clear_checkpoint(db_path: str, work_item_id: str) -> None:
     """Delete one checkpoint row after successful completion."""
     _ensure_parent_dir(db_path)
-    with sqlite3.connect(db_path) as conn:
+    with closing(sqlite3.connect(db_path)) as conn, conn:
+        conn.execute("PRAGMA journal_mode=WAL")
         conn.execute(
             "DELETE FROM agent_history_checkpoints WHERE work_item_id = ?",
             (work_item_id,),
@@ -108,7 +113,8 @@ def cleanup_stale_checkpoints(db_path: str, max_age_hours: int = 24) -> int:
     """Delete checkpoints older than ``max_age_hours`` and return rows deleted."""
     _ensure_parent_dir(db_path)
     cutoff = (datetime.now(UTC) - timedelta(hours=max_age_hours)).isoformat()
-    with sqlite3.connect(db_path) as conn:
+    with closing(sqlite3.connect(db_path)) as conn, conn:
+        conn.execute("PRAGMA journal_mode=WAL")
         cursor = conn.execute(
             "DELETE FROM agent_history_checkpoints WHERE updated_at < ?",
             (cutoff,),

--- a/specs/modules/chat.md
+++ b/specs/modules/chat.md
@@ -177,6 +177,10 @@ split into focused companion modules.
 
 ## Change Log
 
+- 2026-02-16: Hardened SQLite reliability in approval, memory, and history stores.
+  Connections now use explicit close semantics (`contextlib.closing` with
+  transactional context), and each connection sets `PRAGMA journal_mode=WAL`
+  on open. (Issue #44)
 - 2026-02-16: Added `ObservableToolset` wrapper (`toolset_wrappers.py`) that
   intercepts all tool calls to log name, duration, and outcome. All toolsets
   returned by `build_toolsets()` are now wrapped for observability. Tool

--- a/specs/modules/memory.md
+++ b/specs/modules/memory.md
@@ -19,6 +19,8 @@ Persistent chat memory with semantic search via SQLite FTS5. The agent retains k
 - `memory_entries` table with FTS5 virtual table over `summary` + `topics`
 - Entries have: id, timestamp, session_id, summary, topics, raw_history_json
 - Search via FTS5 MATCH with BM25 ranking
+- Connections use explicit close semantics (`contextlib.closing` + transaction context)
+- Each SQLite connection enables `PRAGMA journal_mode=WAL`
 
 **Layer 2: Unstructured (workspace files)**
 - `MEMORY.md` — curated long-term knowledge
@@ -48,4 +50,5 @@ Persistent chat memory with semantic search via SQLite FTS5. The agent retains k
 ## References
 
 - Issue: #26
+- Reliability hardening: #44
 - Foundation for: #27 (sliding window context), #28 (subscriptions)


### PR DESCRIPTION
## Summary
All three SQLite stores (approval, memory, history) used `with conn:` which commits but never closes. Fixed with `contextlib.closing()` double context manager. Added `PRAGMA journal_mode=WAL` on every connection.

## Changes
- `approval_store.py`: 6 call sites fixed + WAL in `_connect()`
- `memory_store.py`: 3 call sites fixed + WAL
- `history_store.py`: 5 call sites fixed + WAL
- `specs/modules/chat.md` + `specs/modules/memory.md`: Updated

## Tests
16 targeted tests passed (`test_memory_store`, `test_history_store`, `test_approval_security`)

## Closes #44