### PR TITLE
fix(docker): copy all source modules in Dockerfile (#43)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ENV UV_LINK_MODE=copy
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev
 
-COPY chat.py ./
+COPY *.py ./
+COPY skills/ ./skills/
 RUN useradd --create-home --shell /usr/sbin/nologin appuser && chown -R appuser:appuser /app
 USER appuser
 


### PR DESCRIPTION
## Summary
Dockerfile only copied `chat.py` but runtime imports 25+ local modules. Container startup failed with `ModuleNotFoundError`.

## Changes
- `COPY *.py ./` replaces `COPY chat.py ./`
- `COPY skills/ ./skills/` adds shipped skills

## Closes #43