### PR TITLE
feat: strict tool definitions for OpenRouter (#33)

### DIFF
--- a/chat_runtime.py
+++ b/chat_runtime.py
@@ -228,6 +228,12 @@ async def _strict_tool_definitions(
 
     OpenRouter and OpenAI-compatible providers produce fewer malformed
     tool-call arguments when tool schemas are marked ``strict=True``.
+
+    This is OpenRouter-only because Anthropic's native API does not support
+    the ``strict`` field on tool definitions — it is an OpenAI-compatible
+    extension.  The callback must be async (returning ``Awaitable``) to
+    satisfy PydanticAI's ``ToolsPrepareFunc`` type signature, even though
+    the body performs no I/O.
     """
     return [replace(td, strict=True) for td in tool_defs]
 

--- a/specs/modules/chat.md
+++ b/specs/modules/chat.md
@@ -177,6 +177,8 @@ split into focused companion modules.
 
 ## Change Log
 
+- 2026-02-16: Enable strict tool definitions for OpenRouter provider via
+  `prepare_tools` callback, reducing malformed tool-call arguments. (Issue #33)
 - 2026-02-16: Hardened SQLite reliability in approval, memory, and history stores.
   Connections now use explicit close semantics (`contextlib.closing` with
   transactional context), and each connection sets `PRAGMA journal_mode=WAL`
@@ -217,8 +219,6 @@ split into focused companion modules.
   `build_toolsets()` returns `(toolsets, instructions)`. `build_agent()`
   accepts instructions list, passes to PydanticAI `instructions` param.
   `SKILLS_DIR` env var. (Issue #9)
-- 2026-02-16: Enable strict tool definitions for OpenRouter provider via
-  `prepare_tools` callback, reducing malformed tool-call arguments. (Issue #33)
 - 2026-02-15: Deferred tool approval flow. Agent calls with
   `output_type=[str, DeferredToolRequests]`. CLI gathers human approval
   and re-enqueues. `WorkItemInput` gains `deferred_tool_results_json`,

--- a/tests/test_strict_tools.py
+++ b/tests/test_strict_tools.py
@@ -1,0 +1,45 @@
+"""Tests for _strict_tool_definitions prepare callback."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+from pydantic_ai.tools import ToolDefinition
+
+from chat_runtime import _strict_tool_definitions  # pyright: ignore[reportPrivateUsage]
+
+
+def _make_tool(name: str, *, strict: bool | None = None) -> ToolDefinition:
+    return ToolDefinition(name=name, description=f"{name} tool", strict=strict)
+
+
+def test_strict_sets_true_on_all_tools() -> None:
+    """Every returned ToolDefinition must have strict=True."""
+    defs = [_make_tool("alpha"), _make_tool("beta", strict=False), _make_tool("gamma", strict=None)]
+    ctx: MagicMock = MagicMock()
+    result = asyncio.run(_strict_tool_definitions(ctx, defs))
+    assert result is not None
+    expected_count = 3
+    assert len(result) == expected_count
+    for td in result:
+        assert td.strict is True, f"{td.name} should have strict=True"
+
+
+def test_strict_preserves_other_fields() -> None:
+    """Fields other than strict must remain unchanged."""
+    original = _make_tool("echo")
+    ctx: MagicMock = MagicMock()
+    result = asyncio.run(_strict_tool_definitions(ctx, [original]))
+    assert result is not None
+    td = result[0]
+    assert td.name == "echo"
+    assert td.description == "echo tool"
+
+
+def test_strict_empty_list() -> None:
+    """An empty tool list should return an empty list (not None)."""
+    ctx: MagicMock = MagicMock()
+    result = asyncio.run(_strict_tool_definitions(ctx, []))
+    assert result is not None
+    assert result == []


### PR DESCRIPTION
Adds _strict_tool_definitions async prepare_tools callback that sets strict=True on every ToolDefinition via dataclasses.replace. Only applied on the OpenRouter agent (Anthropic doesn't use OpenAI-style strict schemas). Closes #33.