### PR TITLE
refactor(chat_worker): use run_stream_sync() instead of manual asyncio.run()

### DIFF
--- a/specs/modules/chat.md
+++ b/specs/modules/chat.md
@@ -97,7 +97,7 @@ split into focused companion modules.
 
 - `run_agent_step(work_item_dict)` — `@DBOS.step()`. Passes
   `output_type=[str, DeferredToolRequests]` to all agent calls. Checks for
-  stream handle: if present, uses `agent.run_stream()` for real-time output;
+  stream handle: if present, uses `agent.run_stream_sync()` for real-time output;
   otherwise `agent.run_sync()`. If input carries `deferred_tool_results_json`,
   passes reconstructed approvals to the agent. Returns `WorkItemOutput` as dict.
 - `execute_work_item(work_item_dict)` — `@DBOS.workflow()`. Delegates to

--- a/specs/modules/queue.md
+++ b/specs/modules/queue.md
@@ -98,7 +98,7 @@ either way.
 2. Optionally `register_stream(item.id, handle)` for real-time output
 3. `enqueue(item)` for fire-and-forget, or `enqueue_and_wait(item)` to block
 4. Worker calls `execute_work_item()` → `run_agent_step()`
-5. Worker checks for stream handle: if present → `run_stream()`, else → `run_sync()`
+5. Worker checks for stream handle: if present → `run_stream_sync()`, else → `run_sync()`
 6. Returns `WorkItemOutput` as durable result
 
 ## History Checkpointing
@@ -107,7 +107,7 @@ History checkpointing adds per-round persistence for in-flight work item
 execution so DBOS replay can resume with minimal repeated model work.
 
 - **How it works:** Agent `history_processors` persist serialized message
-  history to SQLite after each model round during `run_sync()` / `run_stream()`.
+  history to SQLite after each model round during `run_sync()` / `run_stream_sync()`.
 - **Recovery flow:** On `run_agent_step()` start, worker loads checkpoint by
   `work_item_id` and prefers it over `WorkItemInput.message_history_json`.
   After successful completion, checkpoint row is cleared.


### PR DESCRIPTION
Closes #58

## Changes

Replaces the manual `asyncio.run()` wrapper around `agent.run_stream()` in `_run_streaming()` with PydanticAI's built-in `agent.run_stream_sync()`.

- Removes `asyncio` import (no longer needed)
- Simplifies `_run_streaming()` from async-wrapped-in-sync to purely synchronous iteration via `StreamedRunResultSync`
- Updates specs to reflect the new API usage

## Verification

- `ruff check`: ✅ pass
- `pyright strict`: ✅ 0 errors