### PR TITLE
feat: FallbackModel for provider resilience (#57)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ ANTHROPIC_MODEL=anthropic:claude-3-5-sonnet-latest
 # AI_TEMPERATURE=0.7
 # AI_MAX_TOKENS=8192
 # AI_TOP_P=0.9
+# Fallback: when BOTH API keys are set, the non-primary provider is used as
+# an automatic fallback via FallbackModel. AI_PROVIDER controls which is primary.
 DBOS_APP_NAME=pydantic_dbos_agent
 DBOS_AGENT_NAME=chat
 DBOS_SYSTEM_DATABASE_URL=sqlite:///dbostest.sqlite

--- a/specs/modules/chat.md
+++ b/specs/modules/chat.md
@@ -175,6 +175,10 @@ split into focused companion modules.
 
 ## Change Log
 
+- 2026-02-16: FallbackModel for provider resilience. When both
+  `ANTHROPIC_API_KEY` and `OPENROUTER_API_KEY` are set, wraps primary
+  and alternate models in `FallbackModel` for automatic retry on provider
+  failure. `AI_PROVIDER` controls which is primary. (Issue #57)
 - 2026-02-16: Added sliding-window context compaction and tool-result truncation
   as history processors. New modules: `context_manager.py`,
   `tool_result_truncation.py`. See `specs/modules/context.md`. (Issue #27)

--- a/tests/test_fallback_model.py
+++ b/tests/test_fallback_model.py
@@ -1,0 +1,58 @@
+"""Tests for FallbackModel provider resilience in chat_runtime."""
+
+from __future__ import annotations
+
+from _pytest.monkeypatch import MonkeyPatch
+from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.models.fallback import FallbackModel
+from pydantic_ai.models.openai import OpenAIChatModel
+
+from chat_runtime import resolve_model
+
+
+def test_anthropic_only_no_fallback(monkeypatch: MonkeyPatch) -> None:
+    """Single Anthropic key produces a plain model string, not FallbackModel."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    model = resolve_model("anthropic")
+
+    assert isinstance(model, str)
+    assert "anthropic" in model
+
+
+def test_openrouter_only_no_fallback(monkeypatch: MonkeyPatch) -> None:
+    """Single OpenRouter key produces an OpenAIChatModel, not FallbackModel."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    model = resolve_model("openrouter")
+
+    assert isinstance(model, OpenAIChatModel)
+    assert not isinstance(model, FallbackModel)
+
+
+def test_both_keys_anthropic_primary(monkeypatch: MonkeyPatch) -> None:
+    """Both keys with AI_PROVIDER=anthropic wraps in FallbackModel."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+    model = resolve_model("anthropic")
+
+    assert isinstance(model, FallbackModel)
+    models = model.models
+    assert isinstance(models[0], AnthropicModel)
+    assert isinstance(models[1], OpenAIChatModel)
+
+
+def test_both_keys_openrouter_primary(monkeypatch: MonkeyPatch) -> None:
+    """Both keys with AI_PROVIDER=openrouter puts OpenRouter first."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+    model = resolve_model("openrouter")
+
+    assert isinstance(model, FallbackModel)
+    models = model.models
+    assert isinstance(models[0], OpenAIChatModel)
+    assert isinstance(models[1], AnthropicModel)


### PR DESCRIPTION
Closes #57

## Changes

- **chat_runtime.py**: Extract `_build_anthropic_model()` and `_build_openrouter_model()` helpers. New `resolve_model(provider)` checks both API keys; when both are set, wraps primary + fallback in `FallbackModel` from `pydantic_ai.models.fallback`. `AI_PROVIDER` controls which is primary.
- **tests/test_fallback_model.py**: 4 tests covering single-provider (no fallback) and dual-provider (fallback with correct order) scenarios.
- **.env.example**: Comment explaining fallback behavior.
- **specs/modules/chat.md**: Changelog entry.