### PR TITLE
feat(otel): add OpenTelemetry instrumentation (#60)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,6 @@ CUSTOM_SKILLS_DIR=skills
 # Sliding-window context management (optional)
 # CONTEXT_WINDOW_TOKENS=100000
 # COMPACTION_THRESHOLD=0.7
+# Optional: OpenTelemetry OTLP endpoint for agent instrumentation.
+# When set, agent.instrument() exports traces to the given collector.
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318

--- a/chat.py
+++ b/chat.py
@@ -18,6 +18,7 @@ from chat_runtime import (
     build_agent,
     build_backend,
     build_toolsets,
+    instrument_agent,
     resolve_workspace_root,
     set_runtime,
 )
@@ -103,6 +104,7 @@ def main() -> None:
             checkpoint_history_processor,
         ],
     )
+    instrument_agent(agent)
     system_database_url = os.getenv(
         "DBOS_SYSTEM_DATABASE_URL",
         "sqlite:///dbostest.sqlite",

--- a/chat_runtime.py
+++ b/chat_runtime.py
@@ -287,3 +287,22 @@ def build_agent(
             prepare_tools=_strict_tool_definitions,
         )
     raise SystemExit("Unsupported AI_PROVIDER. Use 'openrouter' or 'anthropic'.")
+
+
+def instrument_agent(agent: Agent[AgentDeps, str]) -> bool:
+    """Enable OpenTelemetry instrumentation on the agent if configured.
+
+    Activates ``Agent.instrument_all()`` when the ``OTEL_EXPORTER_OTLP_ENDPOINT``
+    environment variable is set, allowing trace export to any OTLP-compatible
+    collector.  Returns ``True`` when instrumentation was applied.
+
+    Uses the class-level ``instrument_all`` so all agents (including any
+    created later) inherit the setting.  The *agent* parameter is accepted
+    for call-site clarity but is not strictly required.
+    """
+    _ = agent  # kept for call-site readability
+    endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if not endpoint:
+        return False
+    Agent.instrument_all()
+    return True

--- a/specs/modules/chat.md
+++ b/specs/modules/chat.md
@@ -49,6 +49,7 @@ split into focused companion modules.
 | `APPROVAL_CLOCK_SKEW_SECONDS` | No | `60` | `ApprovalStore.from_env(base_dir=...)` | Startup invariant with retention + TTL |
 | `SKILLS_DIR` | No | `skills` | `_resolve_shipped_skills_dir()` | Shipped skills path, resolves from `chat.py` dir |
 | `CUSTOM_SKILLS_DIR` | No | `skills` | `_resolve_custom_skills_dir()` | Custom skills path, resolves inside `AGENT_WORKSPACE_ROOT` when relative |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | No | — | `instrument_agent()` | When set, enables OpenTelemetry trace export via `agent.instrument()` |
 
 ## Functions
 
@@ -67,6 +68,8 @@ split into focused companion modules.
 - `build_agent(provider, name, toolsets, instructions)` — Anthropic or
   OpenRouter factory. Passes instructions to PydanticAI's `instructions`
   parameter for automatic system prompt composition.
+- `instrument_agent(agent)` — Enables OpenTelemetry instrumentation when
+  `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Returns `True` if applied.
 
 ### Observability
 
@@ -190,6 +193,10 @@ split into focused companion modules.
   metadata categories added across exec, process, memory, and skill tools.
   Exec/process tools return `ToolReturn` with structured metadata instead of
   raw dicts. (Issue #38, PR #39)
+- 2026-02-16: Added optional OpenTelemetry instrumentation via
+  `instrument_agent()`. When `OTEL_EXPORTER_OTLP_ENDPOINT` is set,
+  `agent.instrument()` exports traces to the configured OTLP collector.
+  Complementary to existing `ObservableToolset`. (Issue #60)
 - 2026-02-16: Replaced module-global active checkpoint state with
   context-local `ContextVar` storage for safer worker execution.
   (Issue #21, PR #23)

--- a/tests/test_otel_instrumentation.py
+++ b/tests/test_otel_instrumentation.py
@@ -1,0 +1,34 @@
+"""Tests for OpenTelemetry agent instrumentation toggle."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from chat_runtime import instrument_agent
+
+
+def test_instrument_called_when_endpoint_set() -> None:
+    """instrument_all() is invoked when OTEL_EXPORTER_OTLP_ENDPOINT is present."""
+    agent = MagicMock()
+    with (
+        patch.dict("os.environ", {"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318"}),
+        patch("chat_runtime.Agent") as mock_cls,
+    ):
+        result = instrument_agent(agent)  # type: ignore[arg-type]
+
+    assert result is True
+    mock_cls.instrument_all.assert_called_once()
+
+
+def test_instrument_skipped_when_endpoint_absent() -> None:
+    """instrument_all() is NOT invoked when the env var is missing."""
+    agent = MagicMock()
+    import os
+
+    with patch.dict("os.environ", {}, clear=False):
+        os.environ.pop("OTEL_EXPORTER_OTLP_ENDPOINT", None)
+        with patch("chat_runtime.Agent") as mock_cls:
+            result = instrument_agent(agent)  # type: ignore[arg-type]
+
+    assert result is False
+    mock_cls.instrument_all.assert_not_called()


### PR DESCRIPTION
## Summary

Adds optional OpenTelemetry instrumentation to the agent stack. When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, `Agent.instrument_all()` is called after agent construction, enabling trace export to any OTLP-compatible collector.

## Changes

- **`chat_runtime.py`**: New `instrument_agent()` function that conditionally calls `Agent.instrument_all()` based on env var presence
- **`chat.py`**: Calls `instrument_agent(agent)` after `build_agent()`
- **`.env.example`**: Documents `OTEL_EXPORTER_OTLP_ENDPOINT` (commented out)
- **`specs/modules/chat.md`**: Updated env var table, functions list, and changelog
- **`tests/test_otel_instrumentation.py`**: Two tests verifying instrument is called/skipped based on env var

## Notes

- Uses `Agent.instrument_all()` (class method) since PydanticAI doesn't expose instance-level `agent.instrument()`
- Complementary to existing `ObservableToolset` — not a replacement
- No new dependencies required (`InstrumentationSettings` ships with `pydantic-ai`)

Closes #60