### PR TITLE
fix(run_simple): add run_simple() wrapper for deferred tool auto-approval (#61)

### DIFF
--- a/run_simple.py
+++ b/run_simple.py
@@ -1,0 +1,94 @@
+"""Convenience wrapper for ``agent.run_sync()`` that auto-approves deferred tools.
+
+``run_simple`` is intended for testing and quick scripting only.  Production
+usage should go through the DBOS queue, which presents deferred tool requests
+to a human for review.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from pydantic_ai import Agent, DeferredToolRequests
+from pydantic_ai.messages import ModelMessage
+from pydantic_ai.tools import DeferredToolResults
+
+from models import AgentDeps
+
+logger = logging.getLogger(__name__)
+
+AgentOutput = str | DeferredToolRequests
+
+_MAX_APPROVAL_ROUNDS = 10
+
+
+@dataclass(frozen=True)
+class SimpleResult:
+    """Return value from :func:`run_simple`."""
+
+    text: str
+    all_messages: list[ModelMessage]
+    approval_rounds: int
+
+
+def run_simple(
+    agent: Agent[AgentDeps, str],
+    prompt: str,
+    deps: AgentDeps,
+    *,
+    message_history: list[ModelMessage] | None = None,
+    max_rounds: int = _MAX_APPROVAL_ROUNDS,
+) -> SimpleResult:
+    """Run an agent synchronously, auto-approving any deferred tool requests.
+
+    This loops up to *max_rounds* times.  Each iteration calls
+    ``agent.run_sync`` with ``output_type=[str, DeferredToolRequests]``.
+    When the result is a ``DeferredToolRequests``, every requested tool is
+    approved and the agent is re-invoked with the approval results until a
+    plain string is returned.
+
+    Raises:
+        RuntimeError: If the agent keeps requesting approvals beyond
+            *max_rounds* iterations.
+    """
+    output_type: list[type[AgentOutput]] = [str, DeferredToolRequests]
+    history = list(message_history) if message_history else []
+    current_prompt: str | None = prompt
+    deferred_results: DeferredToolResults | None = None
+
+    for round_idx in range(max_rounds):
+        result = agent.run_sync(
+            current_prompt,
+            deps=deps,
+            message_history=history,
+            output_type=output_type,
+            deferred_tool_results=deferred_results,
+        )
+        if isinstance(result.output, str):
+            return SimpleResult(
+                text=result.output,
+                all_messages=result.all_messages(),
+                approval_rounds=round_idx,
+            )
+
+        logger.info(
+            "Auto-approving %d deferred tool(s) (round %d)",
+            len(result.output.approvals),
+            round_idx + 1,
+        )
+        deferred_results = _auto_approve(result.output)
+        history = result.all_messages()
+        current_prompt = None
+
+    raise RuntimeError(f"Agent did not produce a text response after {max_rounds} approval rounds.")
+
+
+def _auto_approve(requests: DeferredToolRequests) -> DeferredToolResults:
+    """Build a ``DeferredToolResults`` that approves every requested tool."""
+    from pydantic_ai.tools import DeferredToolApprovalResult
+
+    approvals: dict[str, DeferredToolApprovalResult | bool] = {}
+    for call in requests.approvals:
+        approvals[call.tool_call_id] = True
+    return DeferredToolResults(approvals=approvals)

--- a/specs/modules/chat.md
+++ b/specs/modules/chat.md
@@ -197,6 +197,12 @@ split into focused companion modules.
   `instrument_agent()`. When `OTEL_EXPORTER_OTLP_ENDPOINT` is set,
   `agent.instrument()` exports traces to the configured OTLP collector.
   Complementary to existing `ObservableToolset`. (Issue #60)
+- 2026-02-16: Added ``run_simple`` convenience module (``run_simple.py``) that
+  wraps ``agent.run_sync()`` with automatic deferred-tool approval for testing
+  and scripting use cases.  Calling ``run_sync()`` directly without
+  ``output_type=[str, DeferredToolRequests]`` crashes with a ``UserError``;
+  ``run_simple()`` handles this transparently.
+  (Issue #61)
 - 2026-02-16: Replaced module-global active checkpoint state with
   context-local `ContextVar` storage for safer worker execution.
   (Issue #21, PR #23)

--- a/tests/test_run_simple.py
+++ b/tests/test_run_simple.py
@@ -1,0 +1,80 @@
+"""Tests for the run_simple convenience wrapper."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic_ai import Agent, FunctionToolset, Tool
+
+from models import AgentDeps
+from run_simple import SimpleResult, run_simple
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_WORKSPACE_SENTINEL = "/tmp/test-run-simple-workspace"
+
+
+def _make_deps() -> AgentDeps:
+    from pydantic_ai_backends import LocalBackend
+
+    return AgentDeps(backend=LocalBackend(root_dir=_WORKSPACE_SENTINEL, enable_execute=False))
+
+
+def _echo_tool(text: str) -> str:
+    """Echo the input text back."""
+    return f"echo:{text}"
+
+
+def _build_agent_with_approval() -> Agent[AgentDeps, str]:
+    """Build a test agent with a tool requiring approval."""
+    ts: FunctionToolset[AgentDeps] = FunctionToolset(
+        tools=[Tool(_echo_tool, requires_approval=True)]
+    )
+    return Agent("test", deps_type=AgentDeps, toolsets=[ts])
+
+
+def _build_agent_no_approval() -> Agent[AgentDeps, str]:
+    """Build a test agent with no approval-required tools."""
+    ts: FunctionToolset[AgentDeps] = FunctionToolset(tools=[Tool(_echo_tool)])
+    return Agent("test", deps_type=AgentDeps, toolsets=[ts])
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunSimpleApprovalFlow:
+    """Verify run_simple auto-approves deferred tool requests."""
+
+    def test_auto_approves_deferred_tools(self) -> None:
+        agent = _build_agent_with_approval()
+        result = run_simple(agent, "hello", _make_deps())
+
+        assert isinstance(result, SimpleResult)
+        assert isinstance(result.text, str)
+        assert result.approval_rounds >= 1
+        assert len(result.all_messages) > 0
+
+    def test_no_approval_needed(self) -> None:
+        agent = _build_agent_no_approval()
+        result = run_simple(agent, "hello", _make_deps())
+
+        assert isinstance(result.text, str)
+        assert result.approval_rounds == 0
+
+    def test_max_rounds_exceeded_raises(self) -> None:
+        """An agent that always defers should raise after max_rounds."""
+        # With max_rounds=0 we should immediately raise
+        agent = _build_agent_with_approval()
+        with pytest.raises(RuntimeError, match="did not produce a text response"):
+            run_simple(agent, "hello", _make_deps(), max_rounds=0)
+
+    def test_message_history_passed_through(self) -> None:
+        agent = _build_agent_no_approval()
+        result1 = run_simple(agent, "first", _make_deps())
+        result2 = run_simple(agent, "second", _make_deps(), message_history=result1.all_messages)
+
+        assert isinstance(result2.text, str)
+        assert len(result2.all_messages) > len(result1.all_messages)


### PR DESCRIPTION
## Problem

When calling `agent.run_sync()` directly (not through the DBOS queue), any tool with `requires_approval=True` crashes because PydanticAI raises `UserError` about `DeferredToolRequests` not being in output types.

## Solution

New `run_simple.py` module with a `run_simple()` convenience function that:
1. Calls `agent.run_sync()` with `output_type=[str, DeferredToolRequests]`
2. If result is `DeferredToolRequests`, auto-approves all deferred tools and re-runs
3. Returns a `SimpleResult(text, all_messages, approval_rounds)`
4. Limits approval rounds (default 10) to prevent infinite loops

Intended for testing/scripting only — the queue-based flow handles approval properly via human-in-the-loop.

## Tests

4 new tests covering:
- Auto-approval flow with deferred tools
- No-approval path (tools without `requires_approval`)
- `max_rounds=0` raises `RuntimeError`
- Message history pass-through

## Checklist
- [x] `uv run ruff check .` passes
- [x] `uv run pyright` passes (strict)
- [x] `uv run pytest` passes (51 tests)
- [x] Changelog updated in `specs/modules/chat.md`

Closes #61