### PR TITLE
refactor: replace global mutable state with injected dependencies (#83)

### DIFF
--- a/specs/modules/chat.md
+++ b/specs/modules/chat.md
@@ -81,7 +81,10 @@ split into focused companion modules.
 ### Runtime State
 
 - `Runtime` dataclass holds agent + backend + approval store + unlocked key manager + tool policy for the process lifetime
-- `set_runtime()` / `get_runtime()` — set in `main()`, read by workers
+- `RuntimeRegistry` provides lock-protected runtime storage with
+  `set_runtime()` / `get_runtime()` wrappers for application code
+- `set_runtime_registry()` / `get_runtime_registry()` allow test injection
+  and `reset_runtime()` clears process runtime in tests
 - `_CheckpointContext` + `ContextVar` store active checkpoint metadata per
   execution context for history processor writes
 
@@ -180,12 +183,12 @@ split into focused companion modules.
 
 ## Change Log
 
-- 2026-02-16: Split runtime construction responsibilities into
-  `model_resolution.py` (provider/model/env resolution),
-  `toolset_builder.py` (workspace/backend/toolset assembly + strict tool
-  schema prep), and a slimmer `chat_runtime.py` (runtime singleton +
-  agent construction/instrumentation). Updated `chat.py` and tests to
-  import from the focused modules. (Issue #76)
+- 2026-02-16: Replaced mutable module-global runtime singleton with
+  `RuntimeRegistry` in `chat_runtime.py`. Runtime access now uses
+  lock-protected registry storage with injectable helpers
+  (`get_runtime_registry()` / `set_runtime_registry()`) and explicit
+  `reset_runtime()` support for tests. Existing `get_runtime()` /
+  `set_runtime()` call sites remain stable wrappers. (Issue #83)
 - 2026-02-16: FallbackModel for provider resilience. When both
   `ANTHROPIC_API_KEY` and `OPENROUTER_API_KEY` are set, wraps primary
   and alternate models in `FallbackModel` for automatic retry on provider

--- a/specs/modules/exec.md
+++ b/specs/modules/exec.md
@@ -56,6 +56,12 @@ Uses stdlib `pty.openpty()` — zero external dependencies. Enables interactive 
 
 ## Change Log
 
+- 2026-02-16: Replaced module-level mutable session dict in
+  `exec_registry.py` with a lock-protected `ExecRegistry` class and
+  injectable registry helpers (`get_registry()` / `set_registry()`).
+  Existing module API (`add/get/list_sessions/mark_exited/reset`) now
+  delegates to the active registry instance for safer concurrent access
+  and easier test isolation. (Issue #83)
 - 2026-02-16: Fixed `execute`/`execute_pty` env inheritance to filter dangerous
   parent vars when `env` is omitted, and aligned `_DANGEROUS_ENV_VARS` with
   `LD_PRELOAD` + `PYTHONPATH`. (Issue #78)

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -77,6 +77,23 @@ def test_mark_exited(workspace: Path) -> None:
     assert session.finished_at is not None
 
 
+def test_registry_can_be_replaced_for_injection(workspace: Path) -> None:
+    proc = MagicMock()
+    session = exec_registry.ProcessSession(
+        session_id="isolated",
+        command="echo isolated",
+        process=proc,
+        log_path=workspace / "isolated.log",
+    )
+    isolated_registry = exec_registry.ExecRegistry()
+    previous = exec_registry.set_registry(isolated_registry)
+    try:
+        exec_registry.add(session)
+        assert exec_registry.get("isolated") is session
+    finally:
+        exec_registry.set_registry(previous)
+
+
 def test_cleanup_exec_logs(workspace: Path) -> None:
     log_dir = workspace / ".tmp" / "exec"
     log_dir.mkdir(parents=True)


### PR DESCRIPTION
## Thread-safe registries with dependency injection

### chat_runtime.py
- `RuntimeRegistry` class with `threading.Lock`
- `set_runtime_registry()` / `get_runtime_registry()` for test injection
- `reset_runtime()` for test teardown
- Existing `get_runtime()` / `set_runtime()` preserved as wrappers

### exec_registry.py
- `ExecRegistry` class with `threading.Lock`
- `set_registry()` / `get_registry()` for test injection
- `mark_exited()` closes master_fd outside the lock (avoids deadlock)

### Tests
- `TestRuntimeRegistry`: get-before-set raises, injection works
- `test_registry_can_be_replaced_for_injection`: isolated ExecRegistry

### Verification
- ✅ 40 targeted tests pass
- ✅ Pyright strict: 0 errors
- ✅ Ruff: clean
- ✅ Specs updated (chat.md, exec.md)

**Note:** chat_runtime.py is 414 lines here but will be under 300 after #76 merges (split into model_resolution.py + toolset_builder.py).

Closes #83