### PR TITLE
fix: cap strict tools at 20 to avoid Anthropic 400 error

### DIFF
--- a/specs/modules/chat.md
+++ b/specs/modules/chat.md
@@ -74,7 +74,7 @@ split into focused companion modules.
   Custom skills override shipped skills when names collide.
 - `chat_runtime.build_agent(provider, name, toolsets, system_prompt, options)` — Anthropic/OpenRouter factory
   that resolves model fallback, strict tool preparation, history processors, and model settings.
-- `toolset_builder.strict_tool_definitions(...)` — marks all tools `strict=True` for OpenAI-compatible providers
+- `toolset_builder.strict_tool_definitions(...)` — marks the first `_MAX_STRICT_TOOLS` (20) tools `strict=True` for OpenAI-compatible providers; remaining tools stay non-strict to respect Anthropic's limit
 - `chat_runtime.instrument_agent(agent)` — Enables OpenTelemetry instrumentation when
   `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Returns `True` if applied.
 

--- a/toolset_builder.py
+++ b/toolset_builder.py
@@ -32,6 +32,9 @@ except ModuleNotFoundError as exc:
         "Run `uv sync` so `pydantic-ai-backend==0.1.6` is installed."
     ) from exc
 
+#: Maximum number of tool definitions that may be marked ``strict=True``.
+#: Anthropic's API rejects requests with more than 20 strict tools.
+_MAX_STRICT_TOOLS = 20
 
 _READ_ONLY_EXEC_TOOLS: frozenset[str] = frozenset({"process_list", "process_poll", "process_log"})
 
@@ -193,4 +196,8 @@ async def strict_tool_definitions(
     tool_defs: list[ToolDefinition],
 ) -> list[ToolDefinition] | None:
     """Mark all tool definitions strict for OpenAI-compatible provider schemas."""
-    return [replace(tool_def, strict=True) for tool_def in tool_defs]
+    # Anthropic caps strict tools at _MAX_STRICT_TOOLS.
+    return [
+        replace(tool_def, strict=True) if i < _MAX_STRICT_TOOLS else tool_def
+        for i, tool_def in enumerate(tool_defs)
+    ]


### PR DESCRIPTION
Anthropic limits strict tools to 20. We had 27 marked strict, causing a 400 BadRequestError on every request.

Caps `strict=True` to the first 20 tool definitions; the rest remain non-strict.

Closes #116