### PR TITLE
docs: add research documents

### DIFF
--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,9 @@
+# Research Documents
+
+Inspirational research and analysis informing autopoiesis development. These are point-in-time snapshots, not living documents.
+
+| Document | Topic | Date |
+|----------|-------|------|
+| [agent-benchmarking-strategy.md](agent-benchmarking-strategy.md) | SWE-bench, Terminal-Bench, GAIA — how to benchmark and optimize agent performance | 2026-02-16 |
+| [ai-interface-ux-study.md](ai-interface-ux-study.md) | UI/UX study for human-AI interaction — workflows, interface design, visual language, tech stack | 2026-02-16 |
+| [openclaw-agency-study.md](openclaw-agency-study.md) | Analysis of OpenClaw's high-agency architecture — mechanisms, risks, opportunities | 2026-02-16 |

--- a/docs/research/agent-benchmarking-strategy.md
+++ b/docs/research/agent-benchmarking-strategy.md
@@ -1,0 +1,597 @@
+# Benchmarking & Optimization Strategy for Autopoiesis
+
+> Research date: 2026-02-16 | Target: [autopoiesis](https://github.com/DavSimFel/autopoiesis) — PydanticAI + DBOS durable CLI agent with tool use, cryptographic approval, and skill self-creation
+
+---
+
+## Table of Contents
+
+1. [SWE-bench](#1-swe-bench)
+2. [Terminal-Bench](#2-terminal-bench)
+3. [GAIA](#3-gaia)
+4. [Benchmark Comparison](#4-benchmark-comparison)
+5. [Benchmarking Strategy for Autopoiesis](#5-benchmarking-strategy-for-autopoiesis)
+6. [Tuning & Optimization](#6-tuning--optimization)
+7. [Practical Recommendations](#7-practical-recommendations)
+
+---
+
+## 1. SWE-bench
+
+### How It Works
+
+**SWE-bench** evaluates whether AI systems can resolve real-world GitHub issues. Each task instance provides:
+- A **codebase** (Python repos like Django, scikit-learn, sympy, etc.)
+- An **issue description** (the GitHub issue text)
+
+The agent must produce a **git patch** that resolves the issue. Evaluation runs the repo's test suite in Docker:
+- **FAIL_TO_PASS tests**: Tests that should now pass after the fix
+- **PASS_TO_PASS tests**: Existing tests that must not break
+
+The agent never sees the tests — it must infer what to fix from the issue description alone.
+
+**Key links:**
+- Repo: https://github.com/SWE-bench/SWE-bench
+- Leaderboard: https://www.swebench.com/
+- Paper: https://arxiv.org/abs/2310.06770
+- Dataset: `princeton-nlp/SWE-bench` on HuggingFace
+
+### Dataset Variants
+
+| Variant | Size | Description |
+|---------|------|-------------|
+| **SWE-bench Full** | 2,294 | Original full dataset |
+| **SWE-bench Lite** | 300 | Curated subset, easier to run |
+| **SWE-bench Verified** | 500 | Human-confirmed solvable (with OpenAI Preparedness) |
+| **SWE-bench Multimodal** | ~100+ | Visual/UI issues |
+| **SWE-bench Bash Only** | 500 | Agent can only use bash commands |
+| **SWE-bench Pro** | New | Harder, contamination-resistant (GPL repos) |
+
+**Verified vs Full**: Verified is a curated 500-problem subset where software engineers confirmed each problem is solvable and unambiguous. It's the standard benchmark for agent comparison. Full has noise — some problems may be unsolvable or ambiguous.
+
+### Current SOTA (Feb 2026, SWE-bench Verified)
+
+| Agent/Model | Score |
+|-------------|-------|
+| Claude Opus 4.5 | ~80.9% |
+| Claude Opus 4.6 | ~80.8% |
+| MiniMax M2.5 | ~80.2% |
+| GPT-5.2 | ~80.0% |
+| GLM-5 | ~77.8% |
+| Verdent + Claude Sonnet 4.5 | Surpasses Claude Code |
+| Claude Opus 4.6 (Thinking) | ~79.2% (vals.ai) |
+
+On **SWE-bench Pro**, scores drop dramatically: GPT-5 and Claude Opus 4.1 score only ~23%.
+
+### How Top Agents Approach SWE-bench
+
+**Devin (Cognition):** Fully autonomous agent — doesn't receive file hints. Uses its own file discovery, planning, and iterative editing. Operates "unassisted" (no oracle file list).
+
+**SWE-agent:** The reference scaffold from the SWE-bench team. Provides the LLM with a custom shell interface (ACI — Agent-Computer Interface) with commands for searching, viewing, and editing files. Open source: https://swe-agent.com/
+
+**Claude Code / Codex:** Use tool-augmented agents with bash execution, file editing, and search. Strong system prompts emphasize reading tests, understanding the codebase before editing, and iterative test-driven development.
+
+**Common patterns:**
+1. Locate relevant files (search, grep, repo structure analysis)
+2. Understand the issue and existing tests
+3. Plan the fix
+4. Implement with precise edits
+5. Run tests iteratively until passing
+
+### Integrating a Custom Agent
+
+Your agent needs to produce a **predictions file** — a JSONL where each line is:
+```json
+{"instance_id": "django__django-12345", "model_patch": "diff --git a/..."}
+```
+
+**Integration approach:**
+1. Load the dataset from HuggingFace
+2. For each instance: set up the repo at the correct commit, give your agent the issue text
+3. Let your agent work (browse files, edit, run commands)
+4. Capture the git diff as the patch
+5. Run the SWE-bench evaluation harness:
+
+```bash
+python -m swebench.harness.run_evaluation \
+  --dataset_name princeton-nlp/SWE-bench_Verified \
+  --predictions_path predictions.jsonl \
+  --max_workers 8 \
+  --run_id my-agent-v1
+```
+
+**Or use cloud evaluation:**
+- **Modal**: `--modal true` flag
+- **sb-cli**: AWS-based evaluation tool from the SWE-bench team
+
+### Hardware & Cost
+
+| Resource | Requirement |
+|----------|-------------|
+| Machine | x86_64, 120GB+ disk, 16GB RAM, 8+ CPU cores |
+| Docker | Required, with sufficient virtual disk |
+| Workers | Recommended: `min(0.75 * cpu_count, 24)` |
+| API cost per instance | ~$0.30–$2.00 depending on model and agent complexity |
+| Full Verified run (500 instances) | ~$150–$1,000 in API costs |
+| Time | 4–12 hours depending on concurrency |
+
+---
+
+## 2. Terminal-Bench
+
+### How It Works
+
+**Terminal-Bench** (Stanford × Laude Institute) evaluates AI agents on hard, realistic terminal tasks. Unlike SWE-bench (which focuses on code patches), Terminal-Bench tests end-to-end task completion in real terminal environments.
+
+Each task includes:
+- An **instruction** in English (e.g., "Install Windows XP in QEMU", "Play Zork to max score", "Reshard this dataset")
+- A **test script** that programmatically verifies success
+- An **oracle solution** (reference implementation)
+
+Tasks run in **Docker containers** with full terminal access. The agent interacts via bash.
+
+**Key links:**
+- Website: https://www.tbench.ai/
+- Repo: https://github.com/laude-institute/terminal-bench
+- Paper: https://arxiv.org/abs/2601.11868
+- Harbor framework: https://github.com/laude-institute/harbor
+
+### Task Categories
+
+| Category | Examples |
+|----------|---------|
+| Software Engineering | Compile code, fix build systems, manage dependencies |
+| System Administration | Install OS in VMs, configure servers, manage services |
+| Data Processing | Reshard datasets, ETL pipelines, data transformations |
+| Games | Play Zork to max score, solve terminal games |
+| ML/AI | Cache models for offline use, train models |
+| Debugging | Find and fix system-level issues |
+
+**Key difference from SWE-bench:** Terminal-Bench tasks are broader — not just "fix this issue" but "accomplish this complex terminal task end-to-end." Tasks are designed to be hard to pattern-match from training data.
+
+### Current SOTA (Feb 2026, Terminal-Bench Hard)
+
+| Agent/Model | Score |
+|-------------|-------|
+| Claude Opus 4.6 (Non-reasoning) | 48.5% |
+| GPT-5.2 (xhigh) | 47.0% |
+| Claude Opus 4.5 (Reasoning) | 47.0% |
+| Frontier models | <65% on core benchmark |
+
+No agent scores above 50% on the hard subset — this is a genuinely difficult benchmark.
+
+### Terminal-Bench 2.0 & Harbor
+
+Terminal-Bench 2.0 (Nov 2025) introduced **Harbor**, a new framework for evaluating agents:
+- Supports cloud-deployed containers (Daytona)
+- Unified interface for multiple benchmarks (SWE-bench, LiveCodeBench, etc.)
+- Simple agent integration via Python classes
+
+### Integrating a Custom Agent
+
+**Option A: Terminal-Bench native (tb CLI)**
+```bash
+pip install terminal-bench
+
+tb run \
+  --agent your-agent \
+  --model anthropic/claude-sonnet-4-5 \
+  --dataset-name terminal-bench-core \
+  --dataset-version 0.1.1 \
+  --n-concurrent 8
+```
+
+**Option B: Harbor framework (recommended for custom agents)**
+
+Create a Python agent class:
+```python
+# my_agent.py
+from harbor import Agent
+
+class AutopoiesisAgent(Agent):
+    async def run(self, task_instruction: str, shell) -> None:
+        # Your agent logic here
+        # Use shell.execute("command") to run terminal commands
+        # The agent reads the task instruction and works to complete it
+        pass
+```
+
+Run with Harbor:
+```bash
+harbor run \
+  -d terminal-bench@2.0 \
+  --agent-import-path my_agent:AutopoiesisAgent \
+  -m anthropic/claude-sonnet-4-5 \
+  -n 4
+```
+
+See example: https://github.com/badlogic/pi-terminal-bench (Harbor agent adapter reference)
+
+### Relevance to Autopoiesis
+
+**HIGH relevance.** Autopoiesis is a terminal-native agent with:
+- Shell execution (directly maps to Terminal-Bench tasks)
+- File operations (needed for most tasks)
+- Tool use and planning (required for complex multi-step tasks)
+
+Terminal-Bench is the **most natural fit** for autopoiesis.
+
+---
+
+## 3. GAIA
+
+### How It Works
+
+**GAIA** (General AI Assistants) tests whether AI agents can handle real-world questions that are simple for humans but require multi-step reasoning, tool use, and web interaction.
+
+- **466 curated questions** with unambiguous, factual answers
+- Answers are short: a number, a few words, or a comma-separated list
+- Evaluation: **quasi exact match** against ground truth
+- Questions require: web browsing, file analysis, code execution, multi-modal reasoning
+
+**Key links:**
+- Paper: https://arxiv.org/abs/2311.12983
+- Leaderboard (HF): https://huggingface.co/spaces/gaia-benchmark/leaderboard
+- Leaderboard (HAL/Princeton): https://hal.cs.princeton.edu/gaia
+- Dataset: `gaia-benchmark/GAIA` on HuggingFace
+
+### Difficulty Levels
+
+| Level | Description | Human Performance | Best AI |
+|-------|-------------|-------------------|---------|
+| **Level 1** | Simple, should be solvable by good LLMs | ~95% | ~82% |
+| **Level 2** | Moderate, requires multi-step reasoning + tools | ~93% | ~73% |
+| **Level 3** | Hard, requires long-term planning + sophisticated tool use | ~88% | ~65% |
+| **Overall** | All levels | ~92% | ~75% |
+
+### Current SOTA (Feb 2026, HAL Leaderboard)
+
+| Agent | Model | Accuracy | Cost |
+|-------|-------|----------|------|
+| HAL Generalist Agent | Claude Sonnet 4.5 (Sep 2025) | **74.55%** | $178 |
+| HAL Generalist Agent | Claude Sonnet 4.5 High | 70.91% | $180 |
+| HAL Generalist Agent | Claude Opus 4.1 High | 68.48% | $562 |
+| HF Open Deep Research | GPT-5 Medium | 62.80% | $360 |
+| h2oGPTe Agent (2025) | Proprietary | ~75% | N/A |
+
+### Running GAIA with a Custom Agent
+
+**Option A: UK Gov Inspect framework**
+```bash
+pip install inspect-evals
+uv run inspect eval inspect_evals/gaia --model openai/gpt-4o
+uv run inspect eval inspect_evals/gaia_level1 --model openai/gpt-4o
+```
+
+**Option B: Direct integration**
+1. Load dataset: `datasets.load_dataset("gaia-benchmark/GAIA")`
+2. For each task: give your agent the question (+ any attached files)
+3. Agent uses tools (web search, file analysis, code execution) to find the answer
+4. Collect answers as JSONL:
+```json
+{"task_id": "task_001", "model_answer": "42", "reasoning_trace": "..."}
+```
+5. Submit to HuggingFace leaderboard or self-evaluate on validation split
+
+**System prompt (recommended by GAIA):**
+> "You are a general AI assistant. Report your thoughts, and finish your answer with: FINAL ANSWER: [YOUR FINAL ANSWER]."
+
+### Relevance to Autopoiesis
+
+**MODERATE relevance.** GAIA tests general-purpose tool use and reasoning — areas where autopoiesis has capabilities. However:
+- GAIA requires **web browsing** (autopoiesis may not have this)
+- GAIA requires **file/image analysis** (PDF, spreadsheets, audio)
+- Less focused on terminal/coding skills
+
+GAIA is better as a secondary benchmark to validate general intelligence capabilities.
+
+---
+
+## 4. Benchmark Comparison
+
+| Dimension | SWE-bench Verified | Terminal-Bench | GAIA |
+|-----------|-------------------|----------------|------|
+| **Focus** | Fix GitHub issues (code patches) | Complete terminal tasks end-to-end | Answer real-world questions |
+| **Tasks** | 500 | ~100 (beta) | 466 |
+| **Evaluation** | Test suite pass/fail | Verification scripts | Exact match |
+| **Agent interface** | Produce git diff | Terminal/bash | Free-form + tools |
+| **Domain** | Python repos only | Broad (sysadmin, data, ML, games) | General knowledge + tools |
+| **SOTA** | ~80% | ~48% | ~75% |
+| **Saturation** | Getting saturated | Far from saturated | Approaching saturation |
+| **Cost per run** | $150–$1,000 | $50–$500 | $120–$650 |
+| **Relevance to autopoiesis** | Medium | **High** | Medium |
+| **Setup complexity** | Medium (Docker) | Low (pip + Docker) | Low (HF dataset) |
+
+### Recommendation
+
+**Primary benchmark: Terminal-Bench** — Most aligned with autopoiesis's terminal-native, tool-using design. Far from saturated, so improvements are meaningful.
+
+**Secondary: SWE-bench Verified** — Industry standard, good for credibility and comparison. Well-understood evaluation.
+
+**Tertiary: GAIA** — Tests general reasoning. Useful for validating breadth but requires web browsing capabilities autopoiesis may not have yet.
+
+---
+
+## 5. Benchmarking Strategy for Autopoiesis
+
+### Minimum Viable Benchmarking Setup
+
+**Phase 1: Terminal-Bench (Week 1-2)**
+
+1. Install Terminal-Bench: `pip install terminal-bench`
+2. Create a Harbor agent adapter for autopoiesis
+3. Run on 5-10 tasks manually to validate integration
+4. Run full Terminal-Bench Core (v0.1.1, ~100 tasks)
+5. Record baseline score
+
+**Phase 2: SWE-bench Lite (Week 3-4)**
+
+1. Build an inference harness that:
+   - Loads SWE-bench instances
+   - Gives autopoiesis the issue + repo
+   - Captures the git diff
+   - Formats as predictions JSONL
+2. Run on SWE-bench Lite (300 instances) for faster iteration
+3. Graduate to Verified (500) once the harness is stable
+
+### Reproducible Eval Harness Architecture
+
+```
+autopoiesis-bench/
+├── harness/
+│   ├── swebench_runner.py    # Loads instances, runs agent, captures patches
+│   ├── tbench_adapter.py     # Harbor Agent class wrapping autopoiesis
+│   ├── gaia_runner.py        # Question → agent → answer pipeline
+│   └── metrics.py            # Track cost, latency, tokens, tool calls
+├── configs/
+│   ├── swebench.yaml         # Model, concurrency, dataset variant
+│   ├── tbench.yaml
+│   └── gaia.yaml
+├── results/
+│   ├── YYYY-MM-DD_swebench_v1.json
+│   └── YYYY-MM-DD_tbench_v1.json
+└── scripts/
+    ├── run_swebench.sh
+    ├── run_tbench.sh
+    └── compare_results.py
+```
+
+### Metrics Beyond Pass Rate
+
+| Metric | Why It Matters |
+|--------|----------------|
+| **Pass rate** | Primary success metric |
+| **Cost per task** | API spend efficiency |
+| **Tokens per task** (input/output/reasoning) | Context efficiency |
+| **Tool calls per task** | Agent efficiency |
+| **Time per task** | Latency / user experience |
+| **Pass@k** | Reliability (pass rate over k attempts) |
+| **Error categorization** | Where does the agent fail? (wrong file, wrong fix, timeout, etc.) |
+| **Token-normalized pass rate** | Passes per $1 spent |
+
+### Cost & Time Estimates
+
+| Benchmark | Tasks | Est. API Cost | Est. Time (8 workers) |
+|-----------|-------|---------------|----------------------|
+| Terminal-Bench Core | ~100 | $50–$200 | 2–4 hours |
+| SWE-bench Lite | 300 | $100–$600 | 4–8 hours |
+| SWE-bench Verified | 500 | $150–$1,000 | 6–12 hours |
+| GAIA validation | 165 | $30–$180 | 1–3 hours |
+
+---
+
+## 6. Tuning & Optimization
+
+### How Top Agents Optimize
+
+#### 1. System Prompt Engineering
+
+**SWE-bench optimized prompts typically:**
+- Instruct the agent to **read the issue carefully** and understand the full context
+- Emphasize **exploring the codebase before editing** (grep, find, read related files)
+- Require **running tests** after changes and iterating
+- Limit scope: "Make minimal changes to fix the specific issue"
+- Include repo-specific hints (directory structure, test commands)
+
+**Terminal-Bench optimized prompts:**
+- Emphasize **planning before acting** — decompose the task into steps
+- Instruct verification: "Check your work at each step"
+- Include common patterns: "If you need a package, install it with apt/pip first"
+
+#### 2. Tool Design Patterns
+
+| Pattern | Description | Impact |
+|---------|-------------|--------|
+| **Structured file editing** | Use search-and-replace instead of rewriting whole files | Reduces errors, improves precision |
+| **Test-driven loops** | Run tests → analyze failures → fix → repeat | +10-20% on SWE-bench |
+| **Hierarchical search** | Directory listing → grep → file read (progressive detail) | Reduces token waste |
+| **Checkpoint/rollback** | Save state before risky changes, revert on failure | Prevents cascading errors |
+| **Tool output summarization** | Truncate/summarize long outputs before feeding back | Saves context window |
+
+#### 3. Context Window Management
+
+- **Progressive disclosure**: Start with high-level repo structure, drill into files on demand
+- **Sliding window**: For long files, show relevant sections only
+- **Summary caching**: Summarize previously read files, keep summaries in context
+- **Token budgeting**: Allocate token budgets per phase (exploration: 30%, editing: 50%, testing: 20%)
+
+#### 4. Retrieval and Planning
+
+- **BM25/embedding retrieval**: For SWE-bench, retrieve relevant files based on issue text similarity
+- **Plan-then-execute**: Generate an explicit plan before taking actions. Top agents that plan first score 5-15% higher.
+- **Reflection**: After a failed attempt, explicitly reason about what went wrong before retrying
+
+#### 5. Model Selection
+
+| Scenario | Recommended | Why |
+|----------|-------------|-----|
+| SWE-bench/Terminal-Bench (quality) | Claude Opus 4.5+ / GPT-5+ | Best reasoning, highest scores |
+| SWE-bench (cost-efficient) | Claude Sonnet 4.5 / GPT-5-mini | 80-90% of top performance at 10-20% cost |
+| GAIA | Reasoning models (high budget) | Multi-step reasoning benefits from extended thinking |
+| Rapid iteration/testing | Fast models (Sonnet, GPT-4o) | Quick feedback loops during development |
+
+**Reasoning models** (extended thinking) help most on:
+- Complex multi-step problems
+- Tasks requiring planning
+- GAIA Level 3 tasks
+
+They help least on:
+- Simple file edits
+- Tasks where execution speed matters
+- High-concurrency runs (cost explodes)
+
+#### 6. Cost-Performance Tradeoffs
+
+From HAL GAIA leaderboard data:
+- Claude Sonnet 4.5: **74.55% at $178** (best cost-efficiency)
+- Claude Opus 4.1 High: **68.48% at $562** (3x cost for -6% accuracy)
+- GPT-5 Medium: **62.80% at $360** (2x cost for -12% accuracy)
+
+**Rule of thumb**: Sonnet-class models offer the best accuracy-per-dollar. Use Opus/GPT-5 only when the marginal accuracy matters (competitions, publications).
+
+### Ablation Studies
+
+To measure the impact of individual changes:
+
+1. **Establish a baseline**: Run the full benchmark once with default configuration
+2. **Change one variable at a time**: prompt, tool design, model, etc.
+3. **Run on a consistent subset**: Use the same 50-100 tasks for ablations (faster, cheaper)
+4. **Track all metrics**: Not just pass rate — also cost, tokens, time
+5. **Statistical significance**: Run 2-3 times per configuration (agent behavior is non-deterministic)
+
+**Ablation priority order:**
+1. Model choice (biggest impact)
+2. System prompt
+3. Tool design (search, edit, test loop)
+4. Context management strategy
+5. Planning/reflection steps
+6. Retrieval method
+
+---
+
+## 7. Practical Recommendations
+
+### What Autopoiesis Should Implement First
+
+#### Priority 1: Benchmark Adapter Layer (1-2 days)
+- Create a **non-interactive mode** for autopoiesis (currently it's a CLI chat agent)
+- Accept task instruction as input, produce result as output
+- Disable cryptographic approval for benchmark runs (or auto-approve)
+- Capture all actions for logging/tracing
+
+#### Priority 2: Terminal-Bench Integration (2-3 days)
+- Write a Harbor agent adapter (`AutopoiesisAgent` class)
+- Map Terminal-Bench's shell interface to autopoiesis's tool system
+- Run on 5 tasks, debug, iterate
+
+#### Priority 3: SWE-bench Integration (3-5 days)
+- Build inference pipeline: load instance → run agent → capture diff
+- Handle repo setup (checkout correct commit, install dependencies)
+- Format output as predictions JSONL
+- Run on SWE-bench Lite subset (50 instances)
+
+#### Priority 4: Metrics & Logging (1-2 days)
+- Track: tokens (in/out/reasoning), tool calls, wall time, API cost
+- Save per-task traces for error analysis
+- Build comparison script for before/after runs
+
+#### Priority 5: Optimization Loop (ongoing)
+- Analyze failure modes from baseline runs
+- Tune system prompt based on error patterns
+- Implement test-driven development loop for SWE-bench
+- Add planning step before execution
+
+### Realistic Target Scores (First Run)
+
+| Benchmark | Realistic First Run | After Optimization |
+|-----------|--------------------|--------------------|
+| Terminal-Bench Core | 15-25% | 30-40% |
+| SWE-bench Lite | 10-20% | 25-40% |
+| SWE-bench Verified | 10-18% | 20-35% |
+| GAIA validation | 20-35% | 40-55% |
+
+These assume autopoiesis uses a strong model (Claude Sonnet 4+). The gap to SOTA comes from:
+- Scaffold/agent design (accounts for 20-40% of variance)
+- Tool design and prompting (accounts for 10-20%)
+- Model choice (accounts for 20-30%)
+
+### Continuous Eval Setup
+
+```yaml
+# .github/workflows/benchmark.yml
+name: Benchmark on Release
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest  # or self-hosted with Docker
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Terminal-Bench (subset)
+        run: |
+          pip install terminal-bench
+          tb run \
+            --agent autopoiesis_adapter:Agent \
+            --model anthropic/claude-sonnet-4-5 \
+            --dataset-name terminal-bench-core \
+            --dataset-version 0.1.1 \
+            --n-concurrent 4 \
+            --subset 20  # Run 20 tasks for CI
+      - name: Run SWE-bench (subset)
+        run: |
+          python harness/swebench_runner.py \
+            --dataset princeton-nlp/SWE-bench_Lite \
+            --limit 30 \
+            --run-id "ci-${{ github.sha }}"
+      - name: Compare with baseline
+        run: python scripts/compare_results.py
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: results/
+```
+
+**Cost-conscious CI**: Run a 20-30 task subset on PRs (~$10-30), full runs on releases (~$100-500).
+
+### Summary: Action Plan
+
+| Step | Action | Time | Cost |
+|------|--------|------|------|
+| 1 | Add non-interactive/batch mode to autopoiesis | 1-2 days | $0 |
+| 2 | Write Terminal-Bench Harbor adapter | 2-3 days | $0 |
+| 3 | Run Terminal-Bench baseline (100 tasks) | 1 day | ~$100 |
+| 4 | Analyze failures, tune prompt & tools | 2-3 days | ~$50 |
+| 5 | Write SWE-bench inference harness | 3-5 days | $0 |
+| 6 | Run SWE-bench Lite baseline (300 tasks) | 1 day | ~$300 |
+| 7 | Implement optimization loop (test-driven, planning) | 1 week | ~$200 |
+| 8 | Set up CI benchmark pipeline | 1 day | $0 |
+| **Total** | | **~3 weeks** | **~$650** |
+
+---
+
+## Appendix: Key Resources
+
+| Resource | URL |
+|----------|-----|
+| SWE-bench repo | https://github.com/SWE-bench/SWE-bench |
+| SWE-bench leaderboard | https://www.swebench.com/ |
+| SWE-agent (reference scaffold) | https://swe-agent.com/ |
+| mini-SWE-agent | https://mini-swe-agent.com/ |
+| Terminal-Bench repo | https://github.com/laude-institute/terminal-bench |
+| Terminal-Bench leaderboard | https://www.tbench.ai/leaderboard/terminal-bench/2.0 |
+| Harbor framework | https://github.com/laude-institute/harbor |
+| Harbor adapter docs | https://harborframework.com/docs/adapters |
+| Example Harbor agent | https://github.com/badlogic/pi-terminal-bench |
+| GAIA dataset | https://huggingface.co/datasets/gaia-benchmark/GAIA |
+| GAIA leaderboard (HF) | https://huggingface.co/spaces/gaia-benchmark/leaderboard |
+| GAIA leaderboard (HAL) | https://hal.cs.princeton.edu/gaia |
+| GAIA paper | https://arxiv.org/abs/2311.12983 |
+| Terminal-Bench paper | https://arxiv.org/abs/2601.11868 |
+| SWE-bench paper | https://arxiv.org/abs/2310.06770 |
+| SWE-rebench (decontaminated) | https://swe-rebench.com/ |
+| SWE-bench Pro (Scale AI) | https://scale.com/leaderboard/swe_bench_pro_public |
+| Artificial Analysis TB | https://artificialanalysis.ai/evaluations/terminalbench-hard |

--- a/docs/research/ai-interface-ux-study.md
+++ b/docs/research/ai-interface-ux-study.md
@@ -1,0 +1,736 @@
+# Human-AI Interaction Interface: UX/UI Deep Research Study
+
+**Date:** 2026-02-16  
+**Context:** UI for a fully capable, multimodal AI agent system (Silas) with tool execution, approval workflows, memory, sub-agents, and persistent context.
+
+---
+
+## Table of Contents
+
+1. [Human-AI Interaction Patterns](#1-human-ai-interaction-patterns)
+2. [Interface Functionality](#2-interface-functionality)
+3. [Visual Design Language](#3-visual-design-language)
+4. [Technical Architecture](#4-technical-architecture)
+5. [Recommended Stack](#5-recommended-stack)
+6. [Build Order (MVP → Full)](#6-build-order)
+
+---
+
+## 1. Human-AI Interaction Patterns
+
+### 1.1 Workflow Patterns
+
+Users interact with a capable AI in four distinct modes. The interface must support seamless transitions between all four:
+
+| Mode | Description | When Used | UI Pattern |
+|------|-------------|-----------|------------|
+| **Command** | Quick, imperative requests | "Send this email", "Create a task" | Input bar with slash commands, keyboard shortcuts |
+| **Conversation** | Exploratory dialogue | Brainstorming, Q&A, analysis | Chat thread with branching |
+| **Delegation** | Hand off complex work | "Research X and write a report" | Task card with progress tracking, approval gates |
+| **Monitoring** | Passive oversight of autonomous work | Long-running tasks, background agents | Dashboard with status feeds, notification badges |
+
+**Key insight (Linear's "Design for the AI Age"):** Chat is a "weak and generic form." The interface should be a **workbench** — a structured environment where AI operates within visible, purpose-built UI, not just a conversation window. Chat is one tool on the workbench, not the workbench itself.
+
+**Recommendation:** Default to a **workbench layout** with chat as a panel (not the whole screen). The workbench includes: active task cards, canvas/workspace, and a persistent sidebar for navigation. Chat can be expanded to full-screen when the interaction is purely conversational.
+
+### 1.2 Trust & Control
+
+This is the most critical design challenge. Research from Google's PAIR Guidebook, Microsoft's HAX Toolkit, and Anthropic's usage patterns converges on these principles:
+
+#### Approval Flows
+
+| Risk Level | Pattern | Example |
+|-----------|---------|---------|
+| **No risk** | Auto-execute, log only | Read files, search web, answer questions |
+| **Low risk** | Execute + notify (undo window) | Create/edit documents, schedule events |
+| **Medium risk** | Preview + one-click approve | Send emails, modify data, install packages |
+| **High risk** | Full review + explicit approve | Delete data, financial transactions, external API calls |
+
+**UI implementation:**
+- **Inline approval cards** in the chat stream — not modal dialogs. Show what the AI wants to do, why, and let the user approve/deny/edit inline.
+- **Standing approvals** as a settings panel: "Always allow web searches", "Always ask before sending emails"
+- **Undo timeline**: A global undo rail (like Figma's version history) showing all actions taken, with point-in-time rollback
+- **Audit trail**: Collapsible "activity log" showing every tool call, gate evaluation, and approval decision
+
+#### Constraint Setting
+
+Users should set constraints **proactively** (before delegation), not just reactively:
+- **Budget limits**: Token/cost caps per task, visible as a progress bar
+- **Tool permissions**: Toggle which tools the AI can use (per task or globally)
+- **Scope boundaries**: "Only modify files in /src", "Don't contact anyone external"
+- **Time limits**: Auto-escalate if task takes > N minutes
+
+**Reference:** Microsoft Copilot's principle: "The human is the pilot." Position every action verb as user-initiated: "Summarize with AI" not "AI summarizes."
+
+### 1.3 Attention Management
+
+When should the AI interrupt vs. queue vs. stay silent?
+
+| Urgency | Behavior | Notification |
+|---------|----------|-------------|
+| **Blocking** (needs approval to continue) | Interrupt immediately | Push notification + sound + badge |
+| **Complete** (task finished) | Notify, don't interrupt | Badge + toast, no sound |
+| **Informational** (progress update) | Queue silently | In-app badge only |
+| **Ambient** (background learning) | Don't notify | Visible only in dashboard |
+
+**Design rules:**
+1. **Never interrupt for information the user didn't ask for** — this erodes trust faster than any other pattern
+2. **Batch notifications** — if 3 sub-tasks complete in 10 seconds, send one notification, not three
+3. **Respect focus mode** — when user is typing/working, queue everything except blocking approvals
+4. **Notification center** — a dedicated panel (like macOS Notification Center) for all AI activity, searchable and filterable
+5. **Smart urgency detection** — deadline-approaching items escalate automatically
+
+### 1.4 Multimodal Switching
+
+Research on modality preferences (Apple HIG, Google PAIR):
+
+| Modality | Best For | Context |
+|----------|----------|---------|
+| **Text** | Precise instructions, code, data, async work | Desktop, focused work, public spaces |
+| **Voice** | Quick commands, hands-busy, mobile | Driving, cooking, walking, eyes-occupied |
+| **Screen share** | Debugging, design review, "show me" | Complex visual context |
+| **Live video** | Physical world tasks ("what is this?") | Camera-based identification, spatial tasks |
+
+**Transition design:**
+- **Voice → Text**: Auto-transcription always visible; user can edit transcript before sending
+- **Text → Voice**: Mic button in input bar; long-press for push-to-talk, tap for toggle
+- **Any → Screen share**: Quick-share button that captures current screen/window/selection
+- **Seamless context**: Switching modality shouldn't lose conversation context
+
+**Voice-specific UX:**
+- Push-to-talk as default (always-listening is privacy-hostile for a personal assistant)
+- Voice activity indicator: Subtle waveform animation when AI is "listening"
+- Interruption: User speaking should cancel AI's current audio output immediately
+- Transcription: Show real-time transcript with confidence highlighting (dim uncertain words)
+
+### 1.5 Delegation Depth
+
+| Depth | Duration | Reporting | User Involvement |
+|-------|----------|-----------|-----------------|
+| **Instant** | < 5 sec | Inline result | None — just shows answer |
+| **Quick task** | 5 sec – 2 min | Progress indicator + result | Minimal — approval if needed |
+| **Work item** | 2 min – 1 hr | Task card with live updates | Periodic check-ins, approval gates |
+| **Project** | Hours – days | Dashboard with milestones | Goal-setting, reviews, steering |
+
+**Handoff UX for work items:**
+1. AI presents a **plan preview** before executing (expandable to see sub-steps)
+2. User approves, edits, or rejects the plan
+3. During execution: **live activity feed** in a collapsible panel (not blocking the chat)
+4. On completion: **summary card** with results, artifacts, and verification status
+5. On failure: **error card** with what went wrong, what was tried, and options (retry, modify, escalate)
+
+### 1.6 Context Sharing
+
+Efficient context sharing is about reducing the gap between "what the user sees" and "what the AI knows":
+
+| Method | Use Case | Implementation |
+|--------|----------|---------------|
+| **Drag & drop** | Files, images, screenshots | Drop zone in chat input area |
+| **Clipboard paste** | Images, text, URLs | Auto-detect content type on paste |
+| **Screen capture** | Current visual context | Keyboard shortcut (⌘+Shift+S) or toolbar button |
+| **File picker** | Workspace files | Tree view of accessible files |
+| **URL reference** | Web content | Paste URL → AI fetches and summarizes |
+| **@mention** | Reference previous messages/artifacts | Searchable mention picker |
+
+**Key principle:** The AI should never ask "can you share your screen?" — the UI should make sharing so easy that context flows naturally.
+
+### 1.7 Multi-Agent Visibility
+
+When the AI spawns sub-agents (as Silas does with Proxy → Planner → Executor):
+
+**User-facing model:** Don't expose the multi-agent architecture directly. Instead, show **task decomposition**:
+
+```
+📋 "Research competitors and write report"
+├── 🔍 Searching web for competitors... ✅
+├── 📄 Reading 12 sources... ✅  
+├── ✍️ Writing report draft... ⏳ (73%)
+└── ✅ Verification pending
+```
+
+**Design rules:**
+1. **One AI identity** — users interact with "the AI," not individual agents. The routing is an implementation detail.
+2. **Expand on demand** — collapsed by default, expandable to see sub-tasks, tool calls, and intermediate results
+3. **Cancel at any level** — user can cancel the whole task or individual sub-tasks
+4. **Resource visibility** — show token/cost usage per sub-task (for power users, in a collapsible section)
+
+### 1.8 Group Dynamics
+
+When AI participates in group conversations (Discord, Slack, team chat):
+
+| Principle | Implementation |
+|-----------|---------------|
+| **Speak when spoken to** | Respond to @mentions and direct questions |
+| **Don't dominate** | Never send more than 2 consecutive messages |
+| **Match tone** | Formal in work channels, casual in social |
+| **Defer to humans** | If a human already answered, don't pile on |
+| **Use reactions** | 👍 to acknowledge without adding noise |
+| **Thread replies** | Long responses go in threads, not main channel |
+
+### 1.9 Error Recovery
+
+Errors fall into three categories, each with distinct UX:
+
+| Error Type | Example | UX Pattern |
+|-----------|---------|------------|
+| **Misunderstanding** | AI did the wrong thing | "Not what I meant" button → clarification dialog with original intent |
+| **Failure** | Tool execution failed | Error card with: what failed, why, retry/modify/skip options |
+| **Hallucination** | AI stated something incorrect | Inline correction (user edits AI message) → AI acknowledges and adjusts |
+
+**Key patterns:**
+- **Edit sent messages** — user can edit their own messages to refine instructions, AI re-processes from the edit point
+- **Branch conversations** — "Try again differently" creates a fork, preserving the original path
+- **Correction memory** — corrections are stored so the same mistake isn't repeated
+- **Graceful degradation** — if a tool is unavailable, AI explains what it can't do and suggests alternatives
+
+### 1.10 Progressive Disclosure
+
+| Layer | Audience | What's Visible |
+|-------|----------|---------------|
+| **Simple** | New users | Chat input, AI responses, basic approve/deny |
+| **Standard** | Regular users | + Task cards, file browser, notification center, settings |
+| **Power** | Advanced users | + Audit log, token usage, raw tool calls, plan YAML, custom constraints |
+| **Developer** | System admins | + Gate configuration, model selection, system prompts, API access |
+
+**Implementation:** Not separate modes — progressive disclosure through:
+- Collapsible sections (default collapsed for simple, expanded for power)
+- Settings toggle: "Show detailed activity" 
+- Keyboard shortcuts for power features
+- Right-click context menus with advanced options
+
+---
+
+## 2. Interface Functionality
+
+### 2.1 Text Chat
+
+| Feature | Priority | Implementation Notes |
+|---------|----------|---------------------|
+| Streaming text | P0 | Token-by-token rendering with cursor animation |
+| Rich content | P0 | Markdown with tables, code blocks (syntax highlighted), LaTeX, images |
+| Message editing | P0 | Edit sent messages → AI reprocesses from that point |
+| Branching | P1 | Fork conversation at any message; tree view in sidebar |
+| Threading | P1 | Reply to specific messages; collapsible thread view |
+| Search | P1 | Full-text search across all conversations with filters |
+| Bookmarks/pins | P2 | Pin important messages or AI outputs |
+| Message reactions | P2 | Quick feedback (👍/👎) that feeds into AI memory |
+| File attachments | P0 | Drag-drop, paste, file picker — images, docs, code files |
+| Code execution | P1 | Inline "Run" button on code blocks (sandboxed) |
+| Copy controls | P0 | One-click copy for code blocks, tables, entire responses |
+
+**Streaming UX specifics:**
+- Show a subtle pulsing cursor during generation
+- Allow user to **stop generation** at any point
+- Progressive rendering: headings and structure appear first, then fill in
+- Don't scroll-jack: if user has scrolled up, don't auto-scroll. Show a "↓ New content" badge instead
+
+### 2.2 Voice
+
+| Feature | Priority | Notes |
+|---------|----------|-------|
+| Push-to-talk | P0 | Hold spacebar or dedicated button; default mode |
+| Voice toggle | P1 | Tap to start/stop continuous listening |
+| Real-time transcription | P0 | Show transcription as user speaks |
+| AI voice output | P1 | Natural TTS with interruption support |
+| Voice activity indicator | P0 | Visual feedback when mic is active |
+| Wake word (optional) | P3 | "Hey Silas" — only for hands-free scenarios |
+| Language detection | P2 | Auto-detect and transcribe multiple languages |
+
+### 2.3 Video/Screen
+
+| Feature | Priority | Notes |
+|---------|----------|-------|
+| Screen sharing for context | P1 | Share screen/window/region so AI can see what you see |
+| Camera input | P2 | "What is this?" — point camera at something |
+| AI-generated visuals | P1 | Charts, diagrams, code previews rendered inline |
+| Live annotation | P2 | AI can highlight/annotate on shared screen |
+
+### 2.4 Canvas/Workspace
+
+The **canvas** is a persistent, shared workspace that lives alongside (or replaces) chat for certain tasks. Inspired by: Claude's Artifacts, Cursor's editor, Notion's blocks.
+
+| Feature | Priority | Notes |
+|---------|----------|-------|
+| Document editor | P1 | Rich text editing with AI collaboration (suggest/edit modes) |
+| Code editor | P1 | Monaco-based with AI inline completions |
+| Diagram viewer | P2 | Mermaid/D2 diagram rendering |
+| Split view | P1 | Chat on left, canvas on right |
+| Version history | P1 | Every AI edit tracked, diffable, revertable |
+| Multiple canvases | P2 | Tabs/panels for different artifacts |
+
+### 2.5 Notifications
+
+| Platform | Behavior |
+|----------|----------|
+| **Desktop** | Native OS notifications for blocking/complete; toast for informational |
+| **Mobile** | Push notifications with rich previews; grouped by task |
+| **Watch** | Haptic for blocking approvals only |
+| **Email** | Daily digest of completed tasks (optional) |
+
+**Cross-platform sync:** Read state syncs instantly. Dismissing on one device dismisses everywhere.
+
+### 2.6 Settings & Constraints
+
+Organized in three tiers:
+
+**Quick Settings (always accessible):**
+- Current model/mode toggle
+- Voice on/off
+- Notification level (all / important / blocking only)
+
+**AI Behavior (settings panel):**
+- Tool permissions (toggles per tool)
+- Standing approvals manager
+- Budget limits (tokens, cost, time)
+- Response style (concise ↔ detailed slider)
+- Memory management (view, edit, delete memories)
+
+**Advanced (developer panel):**
+- System prompt editor
+- Gate configuration
+- Model selection per agent role
+- API key management
+- Export/import configuration
+
+### 2.7 History & Memory
+
+| Feature | Description |
+|---------|-------------|
+| **Conversation list** | Sidebar with all conversations, searchable, sortable by date/topic |
+| **Memory browser** | Searchable list of stored memories with categories, importance, taint level |
+| **Memory editor** | Edit/delete individual memories; bulk operations |
+| **"What do you know about X?"** | Natural language memory query |
+| **Context inspector** | What the AI currently "sees" — system prompt, active memories, context budget usage |
+
+### 2.8 Dashboard
+
+| Widget | Content |
+|--------|---------|
+| **Active tasks** | Currently running work items with progress bars |
+| **Recent activity** | Timeline of recent actions, approvals, completions |
+| **Cost tracker** | Token usage, API costs, budget remaining (daily/monthly) |
+| **System health** | Connection status, model availability, queue depth |
+| **Quick actions** | Frequently used commands, pinned workflows |
+
+---
+
+## 3. Visual Design Language
+
+### 3.1 Design Philosophy
+
+**Recommendation: "Warm Minimal"** — the intersection of Linear's precision and Apple's warmth.
+
+Principles:
+1. **Content-first density** — No decorative chrome. Every pixel serves communication.
+2. **Quiet confidence** — The AI is capable; the UI doesn't need to prove it with flashy effects.
+3. **Readable at scale** — Long AI outputs must be scannable. Use clear hierarchy, generous whitespace, and visible structure.
+4. **Dark mode primary** — AI/developer tools are used in extended sessions. Dark mode reduces eye strain. Light mode as a supported alternative.
+5. **Subtle life** — Micro-animations that suggest intelligence without demanding attention.
+
+**Anti-patterns to avoid:**
+- Glassmorphism (trendy but reduces readability)
+- Excessive gradients (distracting for text-heavy content)
+- Chat bubbles with tails (waste space; use alignment + subtle background differentiation)
+- Anthropomorphic avatars (per Microsoft's guidance: avoid humanizing the AI)
+
+**Reference apps and what to steal:**
+
+| App | Steal This |
+|-----|-----------|
+| **Linear** | Information density, keyboard-first navigation, dark mode palette |
+| **Raycast** | Command palette UX, speed, progressive disclosure |
+| **Arc Browser** | Sidebar organization, spatial layout, playful-but-professional tone |
+| **Vercel Dashboard** | Clean data presentation, deployment status patterns |
+| **Stripe Docs** | Typography hierarchy, code block styling |
+| **Apple Intelligence** | Subtle glow effects for AI activity, system integration feel |
+| **Nothing OS** | Dot-matrix thinking indicators, monospace accents |
+| **Teenage Engineering** | Intentional constraints, personality through typography |
+
+### 3.2 Color System
+
+#### Primary Palette (Dark Mode)
+
+| Role | Color | Hex | Usage |
+|------|-------|-----|-------|
+| **Background** | Near-black | `#0A0A0B` | Main canvas |
+| **Surface** | Dark gray | `#141416` | Cards, panels, elevated surfaces |
+| **Surface elevated** | Medium-dark | `#1C1C1F` | Hover states, active items |
+| **Border** | Subtle gray | `#2A2A2E` | Dividers, card borders |
+| **Text primary** | Off-white | `#EDEDEF` | Main text, headings |
+| **Text secondary** | Medium gray | `#8B8B8F` | Labels, metadata, timestamps |
+| **Text tertiary** | Dark gray | `#5A5A5E` | Disabled text, placeholders |
+
+#### Accent & Semantic
+
+| Role | Color | Hex | Usage |
+|------|-------|-----|-------|
+| **Accent** | Soft blue | `#6E8AFA` | Links, active states, AI activity indicator |
+| **Success** | Muted green | `#4ADE80` | Completed tasks, approvals |
+| **Warning** | Warm amber | `#FBBF24` | Pending approvals, budget warnings |
+| **Error** | Soft red | `#F87171` | Failures, blocked actions |
+| **AI thinking** | Subtle violet glow | `#8B5CF6` | Thinking indicator, processing states |
+
+#### Light Mode
+
+Invert the gray scale. Background: `#FAFAFA`, Surface: `#FFFFFF`, Text: `#111113`. Keep accents the same but increase saturation by ~10%.
+
+#### Accessibility
+
+- All text meets WCAG 2.1 AA (4.5:1 contrast ratio minimum)
+- Interactive elements meet 3:1 contrast against background
+- Never rely on color alone — always pair with icons or text labels
+
+### 3.3 Typography
+
+**Recommended font stack:**
+
+| Role | Font | Fallback | Why |
+|------|------|----------|-----|
+| **UI (sans-serif)** | **Inter** | system-ui, -apple-system | Industry standard for UI. Excellent legibility at small sizes, variable font with optical sizing. Used by Linear, Vercel, Raycast. |
+| **Monospace** | **JetBrains Mono** | ui-monospace, Menlo | Superior code readability, ligatures for operators, designed for extended reading. |
+| **Display (optional)** | **Space Grotesk** | Inter | For hero text, onboarding, marketing. Geometric with character. Pairs well with both Inter and JetBrains Mono. |
+
+**Type scale (base: 14px):**
+
+| Level | Size | Weight | Line Height | Usage |
+|-------|------|--------|-------------|-------|
+| **Display** | 32px | 700 | 1.2 | Page titles, onboarding |
+| **H1** | 24px | 600 | 1.3 | Section headers |
+| **H2** | 18px | 600 | 1.4 | Sub-section headers |
+| **H3** | 16px | 600 | 1.4 | Card titles |
+| **Body** | 14px | 400 | 1.6 | Main text, AI responses |
+| **Body small** | 13px | 400 | 1.5 | Secondary text, metadata |
+| **Caption** | 12px | 400 | 1.4 | Timestamps, labels |
+| **Code** | 13px | 400 | 1.5 | Code blocks, inline code |
+
+**AI response typography:** Use 14px body with 1.6 line height. For long outputs, add subtle left-border accent (2px, accent color at 20% opacity) to distinguish AI content from user content.
+
+### 3.4 Animation & Motion
+
+| Element | Animation | Duration | Easing |
+|---------|-----------|----------|--------|
+| **Thinking indicator** | Three dots with staggered opacity pulse | 1.5s loop | ease-in-out |
+| **Streaming text** | Characters appear with subtle fade-in | 20ms/char | ease-out |
+| **Task progress** | Progress bar with smooth fill | 300ms | ease-out |
+| **Panel transitions** | Slide + fade | 200ms | cubic-bezier(0.4, 0, 0.2, 1) |
+| **Toast notifications** | Slide in from top-right, fade out | 200ms in, 150ms out | ease-out |
+| **Approval card appear** | Scale from 0.95 + fade | 150ms | spring(1, 80, 10) |
+| **Success confirmation** | Subtle green pulse on card | 400ms | ease-out |
+
+**Motion principles:**
+- **Fast** — No animation > 300ms for UI transitions. Users shouldn't wait for animations.
+- **Purposeful** — Animation communicates state change, not decoration
+- **Interruptible** — Any animation can be interrupted by user action
+- **Reduced motion** — Respect `prefers-reduced-motion`: replace animations with instant state changes
+
+### 3.5 Density & Spacing
+
+**Base unit:** 4px grid
+
+| Element | Spacing |
+|---------|---------|
+| **Message gap** | 8px (same sender), 16px (different sender) |
+| **Section padding** | 16px |
+| **Card padding** | 12px |
+| **Input area height** | 48px minimum, grows to 200px max |
+| **Sidebar width** | 260px (collapsible to 48px icon-only) |
+| **Panel width** | 400px min, resizable |
+
+**Message rendering:** Don't use chat bubbles. Use **alignment differentiation**:
+- User messages: Right-aligned, subtle background (`Surface` color), full width available
+- AI messages: Left-aligned, no background (or very subtle), full width
+- System messages: Centered, muted text, small font
+
+This saves ~30% horizontal space vs. traditional bubbles and scales better for long content.
+
+### 3.6 Iconography
+
+**Recommendation: Lucide Icons** (open source, consistent, 24px grid)
+- Style: 1.5px stroke, rounded caps and joins
+- Size: 16px for inline, 20px for buttons, 24px for navigation
+- Color: Inherit from text color (secondary for decorative, primary for interactive)
+- Animated icons for: loading (spinner), AI thinking (subtle pulse), voice (waveform)
+
+### 3.7 Sound Design
+
+| Event | Sound | Character |
+|-------|-------|-----------|
+| **Message sent** | Soft "pop" | Short, satisfying, non-intrusive |
+| **Message received** | Gentle chime | Warm, 2-note ascending |
+| **Approval needed** | Attention tone | Slightly urgent, distinct from received |
+| **Task complete** | Completion chime | Resolved, 3-note ascending |
+| **Error** | Soft discord | Low, brief, not alarming |
+| **Voice mode start** | Subtle activation tone | Clean, indicates listening |
+| **Voice mode end** | Deactivation tone | Complementary to start |
+
+**All sounds optional, off by default for text-only interactions. On by default for voice mode.**
+
+### 3.8 Responsive Design
+
+**Desktop-first, responsive down.**
+
+This is a productivity tool. Desktop is the primary use case. Mobile is for monitoring, quick approvals, and voice interaction — not for heavy work.
+
+| Breakpoint | Layout | Primary Use |
+|-----------|--------|-------------|
+| **≥1280px** | Three-column: sidebar + chat + canvas | Full workbench |
+| **≥768px** | Two-column: sidebar + main (chat or canvas) | Focused work |
+| **<768px** | Single column with tab navigation | Mobile: monitoring, quick interactions |
+
+**Mobile-specific adaptations:**
+- Bottom navigation bar (chat, tasks, notifications, settings)
+- Swipe gestures for navigation between sections
+- Simplified approval cards (big approve/deny buttons)
+- Voice as primary input mode
+
+---
+
+## 4. Technical Architecture
+
+### 4.1 Database: PostgreSQL + JSONB (Not Dgraph)
+
+**Verdict: Skip the graph DB. Use PostgreSQL.**
+
+| Criterion | Dgraph | PostgreSQL + JSONB | Verdict |
+|-----------|--------|-------------------|---------|
+| **Data model fit** | Graph relationships natural for conversation threads, memory links | JSONB handles semi-structured data; recursive CTEs handle tree queries | Conversations are trees, not arbitrary graphs. PostgreSQL handles this well. |
+| **Operational complexity** | Separate service, Raft consensus, custom query language (DQL/GraphQL) | Single service, mature tooling, SQL (universal knowledge) | PostgreSQL wins massively for a single-user self-hosted system |
+| **Ecosystem** | Niche community, uncertain corporate future | Largest RDBMS ecosystem, extensions for everything | PostgreSQL |
+| **Vector search** | Not built-in | pgvector extension — production-grade | PostgreSQL |
+| **Full-text search** | Basic | Built-in tsvector or pg_trgm | PostgreSQL |
+| **Performance** | Overkill for single-user | More than sufficient | PostgreSQL |
+
+**Recommendation:** PostgreSQL 16+ with:
+- `pgvector` for memory embeddings/semantic search
+- JSONB columns for flexible metadata (tool call results, plan YAML, etc.)
+- Standard relational tables for conversations, messages, tasks, audit log
+- Recursive CTEs for conversation tree queries
+
+**Why not SurrealDB?** Interesting multi-model DB but immature (pre-1.0 stability), small community, risky for production. PostgreSQL is boring and correct.
+
+**Note:** Silas v0.1.0 uses SQLite, which is fine for the agent runtime. The web UI can use PostgreSQL for its own data layer (user sessions, UI state, cached data) while Silas continues with SQLite internally. Or: start with SQLite for everything and migrate to PostgreSQL when multi-device/multi-user matters.
+
+### 4.2 Backend: FastAPI (Confirmed)
+
+**Verdict: FastAPI is the right choice.**
+
+| Framework | Pros | Cons | Fit |
+|-----------|------|------|-----|
+| **FastAPI** | Async-native, WebSocket support, Pydantic integration, huge ecosystem, already used in Silas | Not the absolute fastest | ✅ Best fit — matches existing codebase |
+| **Litestar** | Slightly faster, more opinionated | Smaller community, less ecosystem | Marginal gains, not worth switching |
+| **Go (Fiber/Echo)** | Raw performance, goroutines | Different language from Silas, no Pydantic | Only if Python becomes a bottleneck (unlikely for single-user) |
+| **Elixir (Phoenix)** | Best real-time story (channels, presence) | Different language/ecosystem, steep learning curve | Overkill for this use case |
+
+**Key point:** Silas is already Python/FastAPI. The UI backend should be the same service (or a thin extension). Adding a Go or Elixir layer creates unnecessary complexity.
+
+**Streaming pattern:** FastAPI + WebSocket for bidirectional streaming. SSE as a fallback for simpler clients.
+
+### 4.3 Frontend Framework: Svelte 5 (Confirmed, with caveats)
+
+**Verdict: Svelte 5 is a strong choice. React would also work. Svelte wins on DX and performance for a small team.**
+
+| Framework | Pros | Cons | Fit |
+|-----------|------|------|-----|
+| **Svelte 5** | Excellent performance, small bundles, runes reactivity is elegant, less boilerplate, great DX | Smaller ecosystem than React, fewer AI-specific component libraries | ✅ Great for a small team building a custom UI |
+| **React 19** | Largest ecosystem, most AI UI libraries (assistant-ui, Vercel AI SDK), easier hiring | More boilerplate, larger bundles, virtual DOM overhead | Good fallback if ecosystem matters more |
+| **Solid** | Best performance, fine-grained reactivity | Tiny ecosystem, fewer components | Too niche |
+| **Vue 3** | Good middle ground | Smaller AI ecosystem than React | No compelling advantage |
+
+**Risk with Svelte:** The `assistant-ui` library (React) provides excellent AI chat primitives (streaming, tool call rendering, inline approvals). No equivalent exists for Svelte. You'll build more from scratch.
+
+**Mitigation:** Use SvelteKit for routing/SSR + build custom chat components. The streaming/WebSocket layer is framework-agnostic anyway.
+
+### 4.4 UI Library: shadcn-svelte (Not DaisyUI)
+
+**Verdict: shadcn-svelte over DaisyUI.**
+
+| Library | Pros | Cons | Fit |
+|---------|------|------|-----|
+| **shadcn-svelte** | Full source ownership, highly customizable, accessible (built on Bits UI/Melt UI), Tailwind-based, actively maintained for Svelte 5 | Not a traditional library (copies code into project) | ✅ Best for a custom design system |
+| **DaisyUI** | Quick to prototype, many themes, easy to use | Framework-agnostic (no Svelte components), limited customization depth, "themed Bootstrap" feel | ❌ Too opinionated, doesn't match the "warm minimal" vision |
+| **Skeleton UI** | Svelte-native, good out-of-box | Stalled development, migration issues with Svelte 5 | ❌ Risk of abandonment |
+| **Melt UI** | Headless, accessible primitives | Low-level, need to build everything on top | Use as foundation (shadcn-svelte already uses it) |
+
+**shadcn-svelte approach:** Copy component source into your project → full control over every detail → build your design system on top of accessible primitives.
+
+### 4.5 Bundler: Vite (Confirmed)
+
+**Vite is the correct choice.** No alternative is worth considering for a Svelte project. Fast HMR, excellent plugin ecosystem, SvelteKit uses it natively.
+
+### 4.6 Real-Time Communication
+
+| Protocol | Use Case | Why |
+|----------|----------|-----|
+| **WebSocket** | Primary: chat messages, streaming AI responses, task updates, approvals | Bidirectional, persistent connection, low latency (10-50ms). Already in Silas. |
+| **SSE** | Fallback: read-only update streams when WebSocket isn't available | Simpler, works through proxies/CDNs, auto-reconnect built in |
+| **WebRTC** | Voice/video only: real-time audio/video with AI | Required for low-latency audio (<20ms P2P). Use for voice mode and screen sharing. |
+
+**Architecture:**
+- WebSocket for all text/data communication
+- WebRTC for voice and video channels (can use a media server like LiveKit for server-side processing)
+- Fallback: SSE for environments that block WebSocket
+
+### 4.7 State Management
+
+**Svelte 5 runes + server state pattern:**
+
+| Layer | Tool | Responsibility |
+|-------|------|---------------|
+| **Server state** | Custom WebSocket store | Messages, tasks, approvals — source of truth is server |
+| **UI state** | Svelte 5 `$state` runes | Panel visibility, scroll position, input drafts, local preferences |
+| **Derived state** | Svelte 5 `$derived` | Filtered messages, unread counts, task groupings |
+| **Persistent local** | `localStorage` wrapper | Theme preference, sidebar width, collapsed sections |
+
+**Key pattern:** Optimistic UI for user messages (show immediately, confirm via WebSocket ACK). Pessimistic UI for AI actions (show only after server confirms).
+
+### 4.8 Mobile Strategy
+
+**Verdict: PWA first, Tauri later if needed.**
+
+| Approach | Pros | Cons | Recommendation |
+|----------|------|------|---------------|
+| **PWA** | Single codebase, instant deployment, no app store | Limited iOS push notifications (improving), no system-level integration | ✅ MVP and primary strategy |
+| **Tauri v2** | Native wrapping, system tray, smaller than Electron, mobile support | Adds build complexity, Rust dependency | ✅ Phase 2: desktop app for system tray + global shortcuts |
+| **Capacitor** | App store distribution, native APIs | Another abstraction layer | Only if app store presence is required |
+
+**PWA features to leverage:**
+- Service worker for offline message drafting
+- Push notifications (Web Push API)
+- Install prompt for home screen
+- Background sync for queued messages
+
+### 4.9 Authentication
+
+For a single-user self-hosted system:
+- **Local access:** Token-based auth (as Silas already does). Generate a long-lived token on `silas init`.
+- **Remote access:** mTLS or WireGuard tunnel. Don't expose WebSocket to the internet without transport security.
+- **Multi-device:** Session tokens stored per device. One active WebSocket per device; all receive updates.
+- **Always-on:** Tokens don't expire unless revoked. Reconnect silently on network changes.
+
+### 4.10 Offline
+
+| Feature | Offline Behavior |
+|---------|-----------------|
+| **View history** | ✅ Cached in IndexedDB |
+| **Draft messages** | ✅ Stored locally, sent on reconnect |
+| **View tasks** | ✅ Last-known state cached |
+| **New AI interactions** | ❌ Requires server |
+| **Approvals** | ❌ Requires server (security critical) |
+
+### 4.11 Performance
+
+| Concern | Solution |
+|---------|----------|
+| **Long message lists** | Virtual scrolling (svelte-virtual-scroll or custom). Only render visible messages + buffer. |
+| **Streaming text** | Append to DOM incrementally. Don't re-render entire message on each token. |
+| **Large code blocks** | Lazy syntax highlighting (highlight on scroll into view) |
+| **Images** | Lazy loading with blur-up placeholders |
+| **Search** | Client-side index (FlexSearch) for recent messages; server-side for full history |
+| **Bundle size** | Code splitting per route. Main chat bundle < 100KB gzipped. |
+
+### 4.12 Deployment
+
+**Self-hosted first.** This is a personal AI agent — it should run on user's hardware.
+
+| Option | Setup | Use Case |
+|--------|-------|----------|
+| **Docker Compose** | `docker compose up` — single command | Primary deployment: Silas + UI + PostgreSQL |
+| **Bare metal** | `pip install silas` + systemd service | Advanced users, existing servers |
+| **Cloud VM** | Docker on a VPS | Remote access, always-on |
+
+---
+
+## 5. Recommended Stack
+
+| Layer | Choice | Justification |
+|-------|--------|---------------|
+| **Database** | PostgreSQL 16 + pgvector (or SQLite for MVP) | Proven, extensible, handles all data patterns. SQLite fine to start. |
+| **Backend** | FastAPI (Python 3.13+) | Already the Silas runtime. One codebase, one language. |
+| **Real-time** | WebSocket (primary) + WebRTC (voice/video) | Bidirectional for chat, low-latency for media |
+| **Frontend** | SvelteKit + Svelte 5 | Best DX/performance ratio for a small team. Runes reactivity is excellent. |
+| **UI components** | shadcn-svelte (built on Bits UI/Melt UI) | Full source ownership, accessible, customizable |
+| **Styling** | Tailwind CSS 4 | Utility-first, works perfectly with shadcn-svelte |
+| **Icons** | Lucide | Clean, consistent, extensive |
+| **Fonts** | Inter + JetBrains Mono | Industry standard pairing |
+| **Bundler** | Vite (via SvelteKit) | No competition for this stack |
+| **Mobile** | PWA (phase 1) → Tauri v2 (phase 2) | Ship fast with PWA, add native features later |
+| **Deployment** | Docker Compose | Single-command setup |
+
+---
+
+## 6. Build Order
+
+### Phase 1: Core Chat (Weeks 1-3)
+
+**Goal:** Replace the current static PWA with a real chat interface.
+
+1. **SvelteKit project setup** with shadcn-svelte, Tailwind, Inter/JetBrains Mono fonts
+2. **WebSocket connection** to existing Silas backend
+3. **Chat interface** — message list with virtual scrolling, streaming text rendering, input bar
+4. **Message rendering** — Markdown (with GFM tables, code highlighting, images)
+5. **Basic dark theme** following the color system above
+6. **Responsive layout** — desktop two-panel (sidebar + chat), mobile single-column
+
+**Deliverable:** A functional chat that replaces `web/index.html` with dramatically better UX.
+
+### Phase 2: Delegation & Control (Weeks 4-6)
+
+**Goal:** Expose Silas's approval/task system through proper UI.
+
+1. **Approval cards** — inline approve/deny/edit for pending actions
+2. **Task cards** — work item status, progress bars, expandable sub-tasks
+3. **Notification system** — toast notifications, unread badges
+4. **Conversation history** — sidebar list, search, persistence
+5. **Settings panel** — tool permissions, standing approvals, budget limits
+
+**Deliverable:** Users can delegate tasks, approve actions, and monitor progress.
+
+### Phase 3: Workbench (Weeks 7-10)
+
+**Goal:** Move beyond chat into structured work.
+
+1. **Canvas panel** — split view with document/code editor alongside chat
+2. **File browser** — tree view of workspace files
+3. **Dashboard** — active tasks, cost tracking, system health
+4. **Memory browser** — view/edit/delete AI memories
+5. **Audit log viewer** — collapsible activity timeline
+
+**Deliverable:** Full workbench experience for power users.
+
+### Phase 4: Multimodal (Weeks 11-14)
+
+**Goal:** Voice and visual interaction.
+
+1. **Voice mode** — push-to-talk, real-time transcription, AI voice output
+2. **Screen sharing** — capture and share screen context with AI
+3. **Image/file handling** — drag-drop upload, inline preview, AI analysis
+4. **PWA enhancements** — push notifications, offline drafts, install prompt
+
+**Deliverable:** Multimodal interaction across desktop and mobile.
+
+### Phase 5: Polish & Native (Weeks 15+)
+
+1. **Light mode** theme
+2. **Conversation branching** — fork at any message
+3. **Keyboard shortcuts** — Raycast-style command palette (⌘+K)
+4. **Tauri desktop wrapper** — system tray, global shortcuts
+5. **Sound design** — notification chimes, voice mode indicators
+6. **Onboarding flow** — progressive disclosure for new users
+7. **Performance optimization** — bundle analysis, lazy loading, caching strategies
+
+---
+
+## Appendix: Key References
+
+| Resource | URL | Key Takeaway |
+|----------|-----|-------------|
+| Google PAIR Guidebook | https://pair.withgoogle.com/guidebook/ | Trust calibration, mental models, human-AI collaboration patterns |
+| Microsoft HAX Toolkit | https://aka.ms/haxtoolkit/ | 18 guidelines for human-AI interaction |
+| Microsoft Copilot UX Guidance | https://learn.microsoft.com/en-us/microsoft-cloud/dev/copilot/isv/ux-guidance | Immersive/Assistive/Embedded frameworks, foundational principles |
+| Linear "Design for the AI Age" | https://linear.app/now/design-for-the-ai-age | Workbench metaphor, form follows function, chat is a weak form |
+| shadcn-svelte | https://shadcn-svelte.com/ | Component library for Svelte 5 |
+| assistant-ui (React) | https://github.com/assistant-ui/assistant-ui | Reference for AI chat UI patterns (streaming, tool calls, approvals) |
+| Vercel AI SDK | https://ai-sdk.dev/ | Streaming patterns, chat hooks, multi-provider support |
+| Lucide Icons | https://lucide.dev/ | Icon library |
+| Inter Font | https://rsms.me/inter/ | UI typeface |
+| JetBrains Mono | https://www.jetbrains.com/lp/mono/ | Monospace typeface |

--- a/docs/research/openclaw-agency-study.md
+++ b/docs/research/openclaw-agency-study.md
@@ -1,0 +1,543 @@
+# OpenClaw Agency Study: Architecture, Risks, and Opportunities
+
+*Deep analysis of how OpenClaw achieves high agency, its downsides, and where it could go next.*
+*Prepared 2026-02-16. Grounded in source code review, documentation, and external coverage.*
+
+---
+
+## Table of Contents
+
+1. [Architecture Analysis](#1-architecture-analysis)
+2. [How High Agency Is Achieved](#2-how-high-agency-is-achieved)
+3. [Risks & Downsides](#3-risks--downsides)
+4. [Biggest Opportunities](#4-biggest-opportunities)
+5. [Comparative Analysis](#5-comparative-analysis)
+
+---
+
+## 1. Architecture Analysis
+
+### Core Architecture: Gateway + Agent Loop
+
+OpenClaw is a **single-process Gateway daemon** that owns all messaging surfaces and agent execution. The Gateway:
+
+- Maintains persistent WebSocket connections to channel providers (WhatsApp via Baileys, Telegram via grammY, Discord, Signal, Slack, iMessage, etc.)
+- Exposes a typed WebSocket API for clients (macOS app, CLI, web UI, nodes)
+- Serializes agent runs per-session through a lane/queue system
+- Manages session state, transcripts, and memory on the local filesystem
+
+**Key architectural insight**: OpenClaw is *not* a chatbot wrapper. It's a **resident daemon** — always running, always connected, always available. This is the fundamental difference from stateless API-based assistants.
+
+#### The Agent Loop (`src/auto-reply/reply/agent-runner.ts`)
+
+The agent loop follows this path:
+
+1. **Intake**: Message arrives via any channel → routed to agent via bindings
+2. **Queue**: Serialized per-session (prevents tool/session races)
+3. **Context Assembly**: System prompt + bootstrap files + skills + session history
+4. **Model Inference**: Streamed via pi-agent-core runtime
+5. **Tool Execution**: Model calls tools → results fed back → loop continues
+6. **Reply Delivery**: Streamed back to originating channel
+7. **Persistence**: Session transcript saved as JSONL
+
+The loop supports multi-turn tool use within a single run, streaming output, and automatic compaction when context windows fill.
+
+### Sessions, Heartbeats, and Context
+
+**Sessions** (`src/config/sessions/`): Each conversation gets a unique session key (`agent:<agentId>:<channel>:<peer>`). Direct chats collapse to a main session for continuity. Sessions persist as JSONL transcripts on disk.
+
+**Heartbeats** (`src/auto-reply/heartbeat.ts`): A periodic timer (default every 30 minutes) that triggers a silent agent run. The agent reads `HEARTBEAT.md` for tasks, checks emails/calendar/notifications, and can proactively message the user. If nothing needs attention, it replies `HEARTBEAT_OK` silently. The heartbeat prompt is deliberately lean: *"Read HEARTBEAT.md if it exists. Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK."*
+
+**Context assembly** (`src/agents/system-prompt-params.ts`): The system prompt is built fresh each run and includes:
+- Tool descriptions and availability
+- Safety guardrails (advisory, not enforced)
+- Workspace bootstrap files (AGENTS.md, SOUL.md, USER.md, TOOLS.md, MEMORY.md) — injected directly into context
+- Skills prompt (available tools/integrations)
+- Runtime info (host, OS, model, timezone)
+- Current date/time
+
+Bootstrap files are capped at 20KB per file, 24KB total. This is important: the persona and memory are literally in the prompt on every turn.
+
+### Tool System
+
+The tool surface is extensive (`src/agents/tools/`):
+
+| Tool | Capability |
+|------|-----------|
+| `exec` / `process` | Shell commands with background execution, PTY support |
+| `read` / `write` / `edit` / `apply_patch` | Full filesystem access |
+| `browser` | Chromium automation (Playwright-based), screenshots, DOM snapshots |
+| `message` | Send/edit/delete messages across all connected channels |
+| `web_search` / `web_fetch` | Brave Search API + URL fetching with readability extraction |
+| `cron` | Schedule recurring tasks |
+| `nodes` | Control paired phones/desktops (camera, screen, location, run commands) |
+| `canvas` | Render live HTML/CSS/JS surfaces on connected devices |
+| `memory_search` / `memory_get` | Semantic search over memory files |
+| `sessions_spawn` | Spawn sub-agents for parallel work |
+| `tts` | Text-to-speech |
+| `image` | Vision model analysis |
+
+**Tool policy pipeline** (`src/agents/tool-policy-pipeline.ts`): Tools are filtered through a multi-layer policy: profile → provider → global → agent → group. Each layer can allowlist or denylist tools. This is the primary hard enforcement mechanism.
+
+### Memory System
+
+Memory is **plain Markdown on disk** — not a vector database, not a proprietary format:
+
+- `MEMORY.md`: Curated long-term memory (injected into context every turn)
+- `memory/YYYY-MM-DD.md`: Daily notes (accessed on demand via `memory_search`)
+- Vector index: SQLite + sqlite-vec for semantic search over memory files
+- Hybrid search: BM25 keyword + vector similarity, merged with configurable weights
+- Pre-compaction memory flush: When context nears the limit, a silent turn prompts the model to write durable notes before compaction erases the conversation
+
+**Key design choice**: Files are the source of truth. The vector index is just an access accelerator. This means memory is human-readable, auditable, editable, and portable.
+
+### Sub-Agent Orchestration
+
+Sub-agents (`src/agents/subagent-registry.ts`) run in isolated sessions with their own context windows. Key properties:
+
+- Spawned via `sessions_spawn` with a task description
+- Run in `agent:<agentId>:subagent:<uuid>` sessions
+- Results auto-announce back to the requester chat
+- Configurable nesting (default depth 1, max 2 for orchestrator patterns)
+- Concurrency-limited (default 8 global, 5 per agent)
+- Auto-archived after 60 minutes
+- Can use different/cheaper models than the main agent
+
+### Channel Integrations
+
+OpenClaw connects to channels as a **native participant**, not through APIs that feel bolted-on:
+
+- **WhatsApp**: Baileys (Web protocol), full bidirectional messaging
+- **Telegram**: grammY bot framework
+- **Discord**: discord.js with full guild/channel management
+- **Signal**: signal-cli integration
+- **iMessage**: Local imsg CLI (macOS only)
+- **Slack**: Web API + Events API
+- **Others**: Matrix, Mattermost, Line, Google Chat, Microsoft Teams, Zalo — via plugin system
+
+Multi-agent routing means different channels (or even different peers on the same channel) can be routed to different agents with different personas, workspaces, and tool policies.
+
+### Node Pairing
+
+Nodes (`src/node-host/`, `src/pairing/`) are physical devices (iPhone, Android, Mac, headless Linux) that connect to the Gateway via WebSocket:
+
+- Expose commands: `camera.snap`, `screen.record`, `location.get`, `canvas.*`, `run`
+- Device-based pairing with approval flow
+- Can execute commands on the device (with approval)
+- Canvas surfaces render live on the device
+
+This extends the agent's reach to the physical world — it can take photos, check location, display dashboards, and run device-local commands.
+
+### Cron/Scheduling
+
+The cron system (`src/cron/`) provides:
+
+- Standard cron expressions for recurring tasks
+- Isolated agent runs for each job
+- Delivery to specific channels
+- Run logging and timeout enforcement
+
+Combined with heartbeats, this enables truly proactive behavior — the agent doesn't just respond, it *acts on schedule*.
+
+### Configuration and Persona System
+
+Identity is defined through workspace files:
+
+- **`SOUL.md`**: Core identity, personality, values, communication style
+- **`AGENTS.md`**: Operating procedures, safety rules, memory management protocols
+- **`USER.md`**: Information about the human (preferences, context, relationships)
+- **`TOOLS.md`**: Local tool configurations, API endpoints, credentials references
+- **`HEARTBEAT.md`**: Proactive task list
+- **`IDENTITY.md`**: Additional identity context
+
+All injected into the system prompt on every turn. The persona isn't a "custom instruction" bolted onto a generic assistant — it's the foundation of every interaction.
+
+### Skills System
+
+Skills (`src/agents/skills/`) are AgentSkills-compatible folders with a `SKILL.md` frontmatter file that teaches the agent how to use specific tools:
+
+- Three tiers: bundled (shipped with OpenClaw) → managed (`~/.openclaw/skills`) → workspace (`<workspace>/skills`)
+- Gated by environment, config, and binary presence
+- ClawHub marketplace for community skills
+- Skills inject into the system prompt, expanding what the agent knows how to do
+
+---
+
+## 2. How High Agency Is Achieved
+
+### What OpenClaw Can Do That ChatGPT/Claude Web Cannot
+
+| Capability | ChatGPT/Claude Web | OpenClaw |
+|-----------|-------------------|----------|
+| Persistent identity across all interactions | ❌ (session-scoped) | ✅ (SOUL.md + MEMORY.md) |
+| Proactive actions without user trigger | ❌ | ✅ (heartbeats, cron) |
+| Shell command execution | ❌ | ✅ (full shell) |
+| Send messages on your behalf | ❌ | ✅ (WhatsApp, email, etc.) |
+| Control physical devices | ❌ | ✅ (node pairing) |
+| Browser automation | Limited | ✅ (full Playwright) |
+| Parallel background tasks | ❌ | ✅ (sub-agents) |
+| Custom scheduling | ❌ | ✅ (cron) |
+| File system access | ❌ | ✅ (full read/write) |
+| Always-on availability | ❌ | ✅ (daemon) |
+
+### Persistent Identity + Memory → Continuity
+
+The combination of SOUL.md (identity), MEMORY.md (curated experience), and daily notes creates something that stateless assistants fundamentally lack: **a sense of self that persists across conversations**.
+
+Concretely, in the source code:
+- `src/agents/pi-embedded-helpers/bootstrap.ts` loads these files and injects them into every run
+- `src/auto-reply/reply/agent-runner-memory.ts` handles the pre-compaction memory flush
+- `src/memory/manager.ts` maintains the vector index for semantic retrieval
+
+This isn't "memory" as in "the model remembers you like coffee." It's a filesystem-backed identity that includes operating procedures, relationship context, learned preferences, and accumulated experience. The model reads its own biography every time it wakes up.
+
+### Shell + Browser + Messaging → Real-World Impact
+
+The exec tool (`src/agents/bash-tools.exec.ts`) gives the agent a full shell. Combined with browser automation (`src/agents/tools/browser-tool.ts`) and messaging (`src/agents/tools/message-tool.ts`), the agent can:
+
+1. Research something on the web (web_search + web_fetch)
+2. Execute code or scripts to process data (exec)
+3. Automate web interactions that don't have APIs (browser)
+4. Communicate results via any connected channel (message)
+5. Store findings for future reference (write to memory files)
+
+This is the full loop: perceive → think → act → communicate → remember. Most AI tools only cover "think."
+
+### Heartbeat/Cron → Proactive Behavior
+
+The heartbeat system (`src/auto-reply/heartbeat.ts`) transforms the agent from reactive to proactive:
+
+- Default: every 30 minutes, the agent checks if anything needs attention
+- `HEARTBEAT.md` contains standing tasks (check email, monitor notifications, etc.)
+- The agent can independently decide to message the user about important findings
+- Cron jobs enable scheduled workflows (daily reports, periodic checks)
+
+The code deliberately avoids over-triggering: `isHeartbeatContentEffectivelyEmpty()` checks if HEARTBEAT.md has actual content before burning API calls. Late-night hours (23:00-08:00) suppress non-urgent outreach per AGENTS.md conventions.
+
+### Sub-Agent Orchestration → Parallel Work
+
+From `src/agents/subagent-registry.ts`:
+
+- Main agent spawns sub-agents with specific tasks
+- Each runs in its own session with its own context
+- Results announce back automatically
+- Enables patterns like: "Research these 5 topics simultaneously"
+
+The concurrency controls (8 global, 5 per agent, configurable nesting depth) prevent runaway spawning while enabling genuine parallelism.
+
+### Persona System → Coherent Identity
+
+SOUL.md + AGENTS.md + USER.md aren't just "custom instructions." They're injected as **Project Context** in the system prompt, meaning:
+
+- The model sees its identity on every single turn
+- Operating procedures (safety rules, memory management, communication norms) are always present
+- Knowledge about the user is persistent and growing
+
+From the source: `agents.defaults.bootstrapMaxChars` (default 20KB per file) and `bootstrapTotalMaxChars` (24KB total) show these files are treated as first-class context, not afterthoughts.
+
+### Workspace as Filesystem vs. Vector DBs
+
+OpenClaw's choice of plain Markdown over vector databases is deliberate:
+
+**Advantages**:
+- Human-readable and auditable (open any file in a text editor)
+- Editable by both human and AI
+- Git-compatible (version history, collaboration)
+- Portable (no proprietary format lock-in)
+- The model can read/write memory using the same tools it uses for everything else
+
+**Trade-offs**:
+- Less efficient for large-scale retrieval than dedicated vector stores
+- Requires semantic search as an add-on (sqlite-vec) rather than native
+- File size limits and context window constraints cap how much memory can be active
+
+The hybrid approach (files as source of truth + vector index for search) gets most of the benefits of both worlds.
+
+### Node Pairing → Physical Device Extension
+
+Via `src/node-host/runner.ts` and `src/pairing/pairing-store.ts`:
+
+- The agent can take photos through your phone camera
+- Get your current GPS location
+- Display content on your device screen (Canvas)
+- Execute commands on paired devices
+- Record your screen
+
+This extends agency from the digital world to the physical world — a capability none of the major AI assistants offer in an integrated way.
+
+### Comparison to Other Systems
+
+**AutoGPT/BabyAGI**: These pioneered autonomous agent loops but lacked persistence, channel integration, and human-in-the-loop design. They ran once and forgot. OpenClaw is a *resident* — it persists, learns, and integrates into daily life.
+
+**Devin/Cursor/Windsurf**: Coding-focused agents with strong tool use but narrow scope. OpenClaw is a generalist personal assistant, not a coding tool (though it can code via sub-agents and exec).
+
+**Claude Computer Use**: Similar browser/computer control but ephemeral — no persistence, no messaging integration, no heartbeats, no identity. It's a capability demo, not a living assistant.
+
+**Rabbit R1 / Humane AI Pin**: Hardware-centric approaches that tried to replace the phone. OpenClaw works *through* existing devices and channels. No new hardware required.
+
+**Rewind.ai/Granola**: Passive capture and search tools. OpenClaw is active — it doesn't just record, it acts.
+
+---
+
+## 3. Risks & Downsides
+
+### Security: The Attack Surface Is Enormous
+
+**This is OpenClaw's biggest vulnerability.** The threat model (`docs/security/THREAT-MODEL-ATLAS.md`) is thorough but the attack surface is inherently vast:
+
+**Shell access**: The exec tool gives the agent full shell access on the host by default. Sandboxing is **off by default** — a critical design choice that prioritizes usability over security. If prompt injection succeeds (via a malicious web page, email, or skill), the attacker gets shell access to your machine.
+
+**Messaging as attack vector**: Every connected messaging channel is an inbound attack surface. A carefully crafted WhatsApp message could contain prompt injection that triggers the agent to execute commands, exfiltrate data, or send messages to other contacts.
+
+**Skills supply chain**: The Cisco Skill Scanner analysis found real malicious skills in the ClawHub registry, including skills with embedded data exfiltration via curl commands and prompt injections to bypass safety guidelines. 341 malicious ClawHub skills were discovered per external reporting.
+
+**Browser control**: Full Playwright automation means a compromised agent could interact with any website — including banking, email, or social media — on the user's behalf.
+
+**External content wrapping** (`src/security/external-content.ts`) attempts to tag untrusted content with XML markers, but this is a defense-in-depth measure that relies on the model respecting the tags. It's not a hard boundary.
+
+**Real-world incidents**: External coverage documents:
+- API key/credential leaks via prompt injection (reported by Jamieson O'Reilly)
+- MIT Technology Review: "The risks posed by OpenClaw are so extensive that it would probably take someone the better part of a week to read all of the security blog posts"
+- Chinese government public warning about OpenClaw security vulnerabilities
+- WIRED: "I Loved My OpenClaw AI Agent—Until It Turned on Me"
+
+### Safety: Guardrails Are Advisory, Not Enforced
+
+The system prompt includes safety text: *"do not pursue self-preservation, replication, resource acquisition, or power-seeking."* But as the docs themselves state: **"Safety guardrails in the system prompt are advisory. They guide model behavior but do not enforce policy."**
+
+Hard enforcement mechanisms exist but must be configured:
+- Tool policy (allowlists/denylists)
+- Exec approvals (`exec-approvals.json`)
+- Sandboxing (Docker containers — off by default)
+- Channel allowlists (who can message the agent)
+
+The **confirm tier** in AGENTS.md (messages, deletions, external API calls require asking first) is a convention, not a technical control. A hallucinating or manipulated model can bypass it.
+
+**Blast radius**: With full shell access, messaging, and browser control, a bad decision can: delete files, send embarrassing messages, exfiltrate sensitive data, make purchases, or interact with external services — all without requiring user confirmation if tool policies aren't restrictively configured.
+
+### Privacy: Total Access = Total Exposure
+
+OpenClaw has access to:
+- All files on the host filesystem (unless sandboxed)
+- All connected messaging platforms (full message history)
+- Email (via himalaya or other tools)
+- Calendar
+- Browser sessions (including saved passwords/cookies)
+- Phone camera and location (via nodes)
+
+**Data exposure vectors**:
+- All context (including MEMORY.md with personal details) is sent to LLM providers on every API call
+- Session transcripts stored as plaintext JSONL on disk
+- Memory files are unencrypted Markdown
+- If the gateway is exposed beyond localhost, session data is accessible
+
+The Trend Micro analysis highlights: *"Its persistent memory retains long-term context, user preferences, and interaction history, which, when combined with its ability to communicate with other agents, could allow this information to be shared with other agents — including malicious ones."*
+
+### Reliability: LLM Hallucinations with Tool Access
+
+When the model hallucinates with tool access, the consequences are real:
+- Incorrect shell commands can damage the system
+- Wrong message content sent to real contacts
+- File modifications based on misunderstood instructions
+- Browser actions on the wrong website or with wrong data
+
+There's no undo button for a sent WhatsApp message or a deleted file. The AGENTS.md `trash > rm` convention helps, but the model doesn't always follow conventions.
+
+**Single point of failure**: The gateway is one process. If it crashes, all channels disconnect. Systemd/launchd restart helps, but there's no HA or redundancy.
+
+### Cost: Token Usage Adds Up
+
+Running OpenClaw with Opus 4.6 (the recommended model) is expensive:
+
+- **Heartbeats**: Every 30 minutes, even if doing nothing, costs tokens for context loading
+- **Bootstrap files**: AGENTS.md + SOUL.md + USER.md + TOOLS.md + MEMORY.md loaded on every turn (~24KB of context)
+- **Sub-agents**: Each spawns its own context (multiply token costs)
+- **Memory search**: Embedding API calls for indexing and querying
+- **Tool loops**: Multi-tool interactions can run 5-15+ model turns per user message
+
+Conservative estimate: $50-200+/month for an active personal assistant on Opus, depending on usage patterns. Anthropic Pro/Max subscriptions ($100-200/month) help via OAuth but still have rate limits.
+
+### Complexity: Setup Is Non-Trivial
+
+- Requires Node.js ≥22, a running daemon, channel configuration
+- WhatsApp requires QR code pairing (and can break with protocol changes)
+- Telegram/Discord require bot token setup
+- Memory search requires embedding provider configuration
+- Sandboxing requires Docker
+- Skills may require additional binaries
+- Debugging requires understanding of session management, tool policies, channel routing, and agent configuration
+
+The `openclaw onboard` wizard helps, but this is still firmly in "power user" territory.
+
+### Dependency: LLM Provider Lock-In
+
+While OpenClaw supports multiple providers (Anthropic, OpenAI, Google, local models), the experience is heavily optimized for Claude:
+- System prompt structure is Claude-optimized
+- Tool calling patterns work best with Claude
+- OAuth subscription support is Anthropic/OpenAI specific
+- The recommended model (Opus 4.6) is Anthropic-only
+
+If Anthropic changes pricing, rate limits, or API terms, OpenClaw users are disproportionately affected.
+
+### Social: AI Sending Messages on Behalf of Humans
+
+**Trust and authenticity risks**:
+- Recipients don't know they're talking to an AI (WhatsApp messages come from the user's real number)
+- The agent can misrepresent the user's intent
+- Relationship damage from poorly worded or mistimed messages
+- In group chats, the AI participant blurs the line between human and automated responses
+
+AGENTS.md has conventions for group behavior ("don't respond to every message", "use reactions", "stay silent when not adding value") but these are model-followed guidelines, not guarantees.
+
+### Legal: Regulatory Exposure
+
+- **GDPR**: Processing personal data (messages, contacts, location) through external LLM APIs requires consent and data processing agreements
+- **Automated communications**: Sending messages programmatically may violate messaging platform ToS (WhatsApp in particular)
+- **Data retention**: Session transcripts contain full conversation history stored as plaintext
+- **Cross-border data transfer**: Sending European user data to US-based LLM providers
+- **Employment law**: Using AI to send work communications without disclosure
+
+### Model Limitations
+
+- **Context window**: Even large context windows fill up. Compaction helps but loses information.
+- **Rate limits**: Heavy use (especially with sub-agents) can hit API rate limits
+- **Model failures**: The system has failover (`src/agents/model-fallback.ts`) but degradation is visible
+- **Hallucination**: No amount of engineering eliminates this; with tool access, hallucinations become actions
+
+---
+
+## 4. Biggest Opportunities
+
+### Product Opportunities
+
+**Individual power users** (current): Executives, entrepreneurs, researchers, developers who want an AI that actually integrates into their workflow, not a chat window they visit.
+
+**Small teams**: Multi-agent routing already supports multiple workspaces. A team could share a gateway with individual agents per person, each with their own identity and tools.
+
+**Enterprise**: Harder, but the architecture supports it. Per-agent sandboxing, tool policies, and session isolation are the building blocks. Missing: audit logging, compliance controls, SSO, RBAC.
+
+**Vertical specializations**: The skills system enables domain-specific agents. Medical practice management, legal research, real estate operations, trading operations — each needs different tools and knowledge but the same agentic infrastructure.
+
+### Technical Opportunities
+
+**Voice-first interaction**: TTS is already supported. Real-time voice (like GPT-4o voice mode) would be transformative — talking to your always-on assistant naturally.
+
+**Multimodal reasoning**: Vision is supported but underutilized. Continuous camera/screen understanding (like Rewind.ai but active) could enable: "What was that thing I saw on my screen yesterday?"
+
+**Local models**: `node-llama-cpp` integration exists for embeddings. Full local model support for the agent loop would eliminate privacy concerns and API costs for many use cases.
+
+**MCP integration**: The `mcporter` skill exists, but deeper MCP server support would dramatically expand tool availability without custom skills.
+
+**Structured outputs**: Better structured tool results, forms, and data entry flows through Canvas surfaces.
+
+### Integration Opportunities
+
+- **Calendar + email as first-class tools** (not just via skills): Deep Google/Microsoft integration
+- **Banking/payment**: Risky but high-demand — expense management, invoice processing
+- **Smart home**: Beyond node pairing — HomeKit, Home Assistant integration
+- **Code repositories**: Deeper Git/GitHub integration for automated PR reviews, dependency updates
+- **CRM/ERP**: Business workflow automation through Notion/Salesforce/etc.
+
+### Community Opportunities
+
+**Skill marketplace (ClawHub)**: Already exists but needs:
+- Better vetting/scanning (Cisco's Skill Scanner is a start)
+- Reputation/trust scores for skill authors
+- Revenue sharing for skill creators
+- Verified/audited skill tiers
+
+**Open source dynamics**: MIT license enables broad adoption. The challenge is sustaining development while keeping the project open. Community contributions to skills are lower-friction than core contributions.
+
+### Business Model
+
+**Current**: Open source, free. Revenue via Anthropic/OpenAI subscription referrals (presumably).
+
+**Potential models**:
+- Hosted gateway service (OpenClaw Cloud) — manage the infrastructure
+- Premium skills marketplace (revenue share)
+- Enterprise licensing (compliance, audit, support)
+- Pro features (advanced memory, multi-agent orchestration, priority support)
+
+**Competitive moat**: The moat is *not* the code (it's open source). The moat is:
+1. **Channel integration depth** — years of work integrating with messaging platforms' quirky protocols
+2. **Community and skills ecosystem** — network effects from shared skills
+3. **Identity/memory architecture** — the workspace-as-filesystem approach is hard to replicate well
+4. **Trust and brand** — being the first to make this work at scale
+
+### Differentiation
+
+What makes OpenClaw fundamentally different: **it's resident, not visiting.** Every other AI assistant is a place you go. OpenClaw lives where you already are — your WhatsApp, your Telegram, your desktop. It has a persistent identity, accumulated memory, and proactive behavior. It's the difference between a consultant you call and an employee who's always there.
+
+### Emerging Tech Impact
+
+- **Reasoning models**: Extended thinking makes the agent better at complex multi-step tasks
+- **Real-time voice**: Transforms OpenClaw from text-first to voice-first — phone calls, ambient listening
+- **Smaller capable models**: Reduces cost for heartbeats and sub-agents dramatically
+- **Agent-to-agent protocols**: OpenClaw already has multi-agent routing; inter-instance collaboration (Moltbook-style) is the next frontier
+
+### Agent-to-Agent
+
+Multiple OpenClaw instances could:
+- Share knowledge/skills across organizations
+- Coordinate on joint projects
+- Act as specialized team members (researcher, writer, analyst)
+- Create agent networks that extend individual capability
+
+The bindings + multi-agent system already supports this architecturally.
+
+---
+
+## 5. Comparative Analysis
+
+### Comparison Matrix
+
+| Dimension | OpenClaw | ChatGPT + GPTs | Claude Projects + MCP | Microsoft Copilot | AutoGPT/CrewAI | Devin/Cursor | Open Interpreter |
+|-----------|---------|----------------|----------------------|-------------------|---------------|-------------|-----------------|
+| **Agency Level** | Very High | Medium | Medium-High | Medium | High (brittle) | High (coding) | High |
+| **Persistence** | Full (filesystem) | Limited (memory) | Session-scoped | Session-scoped | None | Session-scoped | None |
+| **Identity Continuity** | Full (SOUL.md) | Partial (GPT config) | None | None | None | None | None |
+| **Proactive Behavior** | Yes (heartbeats, cron) | No | No | No | Task-scoped | No | No |
+| **Channel Integration** | 10+ native channels | ChatGPT only | Claude only | M365 suite | None native | IDE only | Terminal only |
+| **Shell Access** | Full | No | Via MCP servers | No | Yes | Yes (scoped) | Yes |
+| **Browser Control** | Full Playwright | Limited | Via MCP | Edge integration | Yes (fragile) | No | Experimental |
+| **Messaging** | Native multi-channel | No | No | Teams/Outlook | No | No | No |
+| **Physical Devices** | Yes (node pairing) | No | No | No | No | No | No |
+| **Memory** | File + vector hybrid | Conversation memory | Project files | Graph/M365 | Short-term only | Codebase indexing | None |
+| **Sub-agents** | Native orchestration | No | No | No | Multi-agent | No | No |
+| **Setup Complexity** | High | Zero | Low | Medium (admin) | High | Low-Medium | Low |
+| **Cost** | $50-200+/month (API) | $20-200/month | $20-200/month | $30/user/month | API costs | $20-40/month | API costs |
+| **Safety Model** | Advisory + configurable policies | Platform-enforced | Platform-enforced | Enterprise controls | Minimal | Scoped to code | Approval-based |
+| **Open Source** | Yes (MIT) | No | No | No | Yes | No (Cursor) | Yes |
+| **Scalability** | Single-user (multi-agent per gateway) | Multi-user | Multi-user | Enterprise | Single-run | Single-user | Single-user |
+
+### Key Differentiators by Competitor
+
+**vs ChatGPT + GPTs**: ChatGPT is sandboxed, ephemeral, and platform-locked. OpenClaw runs on your machine, persists across sessions, integrates with your real tools and channels, and acts proactively. ChatGPT is safer; OpenClaw is more capable.
+
+**vs Claude Projects + MCP**: MCP provides extensible tool access but through Claude's platform. No persistence, no proactive behavior, no native channel integration. Claude Projects offer file context but not a living workspace. OpenClaw uses Claude as a brain but owns the body.
+
+**vs Microsoft Copilot**: Deep M365 integration that OpenClaw can't match, but restricted to the Microsoft ecosystem. No shell access, no custom tools, no physical device control. Better for enterprise email/docs; worse for everything else.
+
+**vs AutoGPT/BabyAGI/CrewAI**: These proved autonomous agents could work but never solved persistence, reliability, or human-in-the-loop design. They run tasks and disappear. OpenClaw is what AutoGPT wanted to be when it grew up.
+
+**vs Devin/Cursor/Windsurf**: Excellent at coding but that's all they do. OpenClaw is a generalist — it can code (via sub-agents), but also manages email, sends messages, controls devices, and acts as a full personal assistant.
+
+**vs Open Interpreter**: Closest analog — local shell + LLM. But Open Interpreter is a CLI tool for single sessions. No persistence, no channels, no heartbeats, no identity, no nodes.
+
+### The Core Insight
+
+OpenClaw occupies a unique position: it's the only system that combines **persistent identity**, **multi-channel presence**, **full tool access**, **proactive behavior**, and **physical device control** in a single, self-hosted package. Every competitor has some of these; none have all of them.
+
+This is also why the security concerns are so acute — the same integration depth that makes it uniquely capable makes it uniquely dangerous if compromised. The question isn't whether OpenClaw is too powerful; it's whether the safety controls can keep pace with the capability.
+
+---
+
+## Summary
+
+OpenClaw represents the most complete implementation of a "personal AI agent" that exists today. Its architecture — a resident daemon with persistent identity, multi-channel messaging, full tool access, proactive scheduling, and physical device control — delivers a level of agency that no competing system matches.
+
+The risks are proportional to the capability. Shell access, messaging, and browser control create an enormous attack surface. Security is configurable but not default. Prompt injection through any connected channel could lead to data exfiltration, unauthorized actions, or system compromise. The Cisco, Trend Micro, and MIT Technology Review analyses are not alarmist — they're accurate assessments of real risks.
+
+The opportunity is to become the operating system for personal AI — the layer between humans and their digital lives. If the security story matures (default sandboxing, better skill vetting, mandatory approval flows for high-risk actions), OpenClaw could transition from a power-user tool to a mainstream platform. The skills ecosystem, multi-agent routing, and channel integration depth create real moats that are hard to replicate.
+
+The fundamental bet: **an AI that lives with you is more valuable than one you visit.** The source code, architecture, and design decisions all serve this thesis. Whether the security challenges can be solved without compromising the agency is the defining question for OpenClaw's future.


### PR DESCRIPTION
Adds three research documents as inspirational/reference material for future development:

- **agent-benchmarking-strategy.md** — SWE-bench, Terminal-Bench, GAIA: how to benchmark and optimize agent performance
- **ai-interface-ux-study.md** — UI/UX study for human-AI interaction: workflows, interface design, visual language, tech stack
- **openclaw-agency-study.md** — Analysis of OpenClaw's high-agency architecture: mechanisms, risks, opportunities

These are point-in-time snapshots, not living documents.