### PR TITLE
feat: non-interactive batch mode (#138)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
             ["agent/cli.py"]="specs/modules/chat.md"
             ["agent/runtime.py"]="specs/modules/chat.md"
             ["agent/worker.py"]="specs/modules/chat.md"
+            ["agent/batch.py"]="specs/modules/chat.md"
             ["model_resolution.py"]="specs/modules/chat.md"
             ["toolset_builder.py"]="specs/modules/chat.md"
             ["db.py"]="specs/modules/memory.md"

--- a/agent/batch.py
+++ b/agent/batch.py
@@ -1,0 +1,115 @@
+"""Non-interactive batch execution for programmatic agent invocation.
+
+Dependencies: agent.runtime, models, run_simple
+Wired in: chat.py → main() (via ``run`` subcommand)
+"""
+
+from __future__ import annotations
+
+import json
+import signal
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from agent.runtime import get_runtime
+from models import AgentDeps
+from run_simple import run_simple
+
+
+@dataclass(frozen=True)
+class BatchResult:
+    """Structured output from a batch run."""
+
+    success: bool
+    result: str | None
+    error: str | None
+    approval_rounds: int
+    elapsed_seconds: float
+
+
+def format_output(result: BatchResult) -> str:
+    """Serialize a BatchResult to JSON."""
+    return json.dumps(
+        {
+            "success": result.success,
+            "result": result.result,
+            "error": result.error,
+            "approval_rounds": result.approval_rounds,
+            "elapsed_seconds": round(result.elapsed_seconds, 3),
+        },
+        ensure_ascii=True,
+        allow_nan=False,
+        indent=2,
+    )
+
+
+def _read_task_stdin() -> str:
+    """Read task from stdin, stripping trailing whitespace."""
+    task = sys.stdin.read().strip()
+    if not task:
+        raise SystemExit("Error: empty task from stdin.")
+    return task
+
+
+def _install_timeout(timeout: int) -> None:
+    """Set a SIGALRM-based timeout (Unix only)."""
+
+    def _on_timeout(_signum: int, _frame: object) -> None:
+        raise TimeoutError(f"Batch run exceeded {timeout}s timeout.")
+
+    signal.signal(signal.SIGALRM, _on_timeout)
+    signal.alarm(timeout)
+
+
+def run_batch(
+    task: str | None,
+    *,
+    output_path: str | None = None,
+    timeout: int | None = None,
+) -> None:
+    """Execute a single task non-interactively and exit."""
+    resolved_task = _read_task_stdin() if task is None or task == "-" else task
+
+    if timeout is not None and timeout > 0:
+        _install_timeout(timeout)
+
+    rt = get_runtime()
+    deps = AgentDeps(backend=rt.backend)
+    start = time.monotonic()
+
+    try:
+        simple_result = run_simple(rt.agent, resolved_task, deps)
+        batch_result = BatchResult(
+            success=True,
+            result=simple_result.text,
+            error=None,
+            approval_rounds=simple_result.approval_rounds,
+            elapsed_seconds=time.monotonic() - start,
+        )
+    except TimeoutError as exc:
+        batch_result = BatchResult(
+            success=False,
+            result=None,
+            error=str(exc),
+            approval_rounds=0,
+            elapsed_seconds=time.monotonic() - start,
+        )
+    except (RuntimeError, OSError, ValueError) as exc:
+        batch_result = BatchResult(
+            success=False,
+            result=None,
+            error=str(exc),
+            approval_rounds=0,
+            elapsed_seconds=time.monotonic() - start,
+        )
+
+    output_json = format_output(batch_result)
+
+    if output_path:
+        Path(output_path).write_text(output_json + "\n", encoding="utf-8")
+    else:
+        print(output_json)
+
+    sys.exit(0 if batch_result.success else 1)

--- a/specs/modules/chat.md
+++ b/specs/modules/chat.md
@@ -22,6 +22,7 @@ split into focused companion modules.
 | `chat_worker.py` | DBOS workflow/step functions, enqueue helpers, history serialization |
 | `chat_approval.py` | Approval scope, request/result serialization, CLI approval collection |
 | `chat_cli.py` | Interactive CLI loop and approval re-enqueue flow |
+| `agent/batch.py` | Non-interactive batch execution with auto-approval and JSON output |
 | `models.py` | `AgentDeps`, `WorkItem`, `WorkItemInput`, `WorkItemOutput`, priority/type enums |
 | `skills.py` | Skill discovery, progressive loading, skills toolset |
 | `work_queue.py` | Queue instance only (no functions importing from `chat.py`) |
@@ -124,6 +125,15 @@ split into focused companion modules.
   (supports approve-all, deny-all, or pick individually); returns serialized
   approval decisions
 
+### Batch Mode
+
+- `run_batch(task, output_path, timeout)` — execute a single task non-interactively
+  using `run_simple()` for auto-approval, produce structured JSON output, and exit
+  with code 0 (success) or 1 (failure). Supports stdin input (`--task -`), file output
+  (`--output`), and SIGALRM-based timeout (`--timeout`).
+- `format_output(result)` — serialize `BatchResult` to JSON
+- `BatchResult` dataclass — success, result text, error, approval_rounds, elapsed_seconds
+
 ### CLI
 
 - `cli_chat_loop()` — interactive loop with approval flow. Each message →
@@ -136,8 +146,9 @@ split into focused companion modules.
 
 ### Entrypoint
 
-- `main()` — load .env → optional `rotate-key` command path → unlock approval key
-  (required) → build stack → set runtime → DBOS launch → chat loop
+- `main()` — load .env → optional `rotate-key` command path → optional `serve` command →
+  build stack → set runtime → if `run` command: batch execution (no DBOS, no approval unlock);
+  otherwise: unlock approval key → DBOS launch → chat loop
 - `_rotate_key(base_dir)` — interactive key rotation; invalidates pending envelopes
 
 ## Deferred Tool Approval Flow
@@ -299,4 +310,6 @@ describe actual enforcement honestly — cwd/path validation, not hard sandbox.
 - 2026-02-16: Modules moved into subdirectories (`agent/`, `approval/`, `display/`, `infra/`, `store/`, `tools/`) as part of subdirectory restructuring (#119)
 - 2026-02-16: Added Dependencies/Wired-in docstring headers (#121)
 - 2026-02-16: Added `serve` subcommand for FastAPI server mode (#126)
+- 2026-02-16: Non-interactive batch mode via `run` subcommand with auto-approval,
+  structured JSON output, timeout, and exit codes (#138)
 - 2026-02-16: Knowledge system integration — startup indexing, knowledge tools wiring, memory store deprecated (#130)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,124 @@
+"""Tests for agent.batch non-interactive batch mode."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.batch import BatchResult, format_output, run_batch
+
+
+class TestFormatOutput:
+    """Verify JSON serialization of BatchResult."""
+
+    def test_success_output(self) -> None:
+        result = BatchResult(
+            success=True,
+            result="hello world",
+            error=None,
+            approval_rounds=0,
+            elapsed_seconds=1.234,
+        )
+        parsed = json.loads(format_output(result))
+        assert parsed["success"] is True
+        assert parsed["result"] == "hello world"
+        assert parsed["error"] is None
+        assert parsed["elapsed_seconds"] == 1.234
+
+    def test_failure_output(self) -> None:
+        result = BatchResult(
+            success=False,
+            result=None,
+            error="something broke",
+            approval_rounds=0,
+            elapsed_seconds=0.5,
+        )
+        parsed = json.loads(format_output(result))
+        assert parsed["success"] is False
+        assert parsed["error"] == "something broke"
+
+
+class TestRunBatchStdinRead:
+    """Verify stdin task reading."""
+
+    def test_empty_stdin_exits(self) -> None:
+        with patch("agent.batch.sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = "  "
+            with pytest.raises(SystemExit, match="empty task"):
+                run_batch(None)
+
+    def test_dash_reads_stdin(self) -> None:
+        with patch("agent.batch.sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = "  "
+            with pytest.raises(SystemExit, match="empty task"):
+                run_batch("-")
+
+
+class TestRunBatchIntegration:
+    """Integration test with mocked runtime."""
+
+    def test_success_writes_output_file(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+
+        from run_simple import SimpleResult
+
+        mock_rt = MagicMock()
+        mock_rt.backend = MagicMock()
+        output_file = tmp_path / "result.json"
+
+        fake_result = SimpleResult(text="done", all_messages=[], approval_rounds=1)
+
+        with (
+            patch("agent.batch.get_runtime", return_value=mock_rt),
+            patch("agent.batch.run_simple", return_value=fake_result),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            run_batch("do something", output_path=str(output_file))
+
+        assert exc_info.value.code == 0
+        parsed = json.loads(output_file.read_text())
+        assert parsed["success"] is True
+        assert parsed["result"] == "done"
+        assert parsed["approval_rounds"] == 1
+
+    def test_failure_exit_code_1(self) -> None:
+        from unittest.mock import MagicMock
+
+        mock_rt = MagicMock()
+        mock_rt.backend = MagicMock()
+
+        with (
+            patch("agent.batch.get_runtime", return_value=mock_rt),
+            patch("agent.batch.run_simple", side_effect=RuntimeError("boom")),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            run_batch("do something")
+
+        assert exc_info.value.code == 1
+
+    def test_timeout_produces_error(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+
+        mock_rt = MagicMock()
+        mock_rt.backend = MagicMock()
+        output_file = tmp_path / "result.json"
+
+        def _slow_run(*_args: object, **_kwargs: object) -> None:
+            raise TimeoutError("Batch run exceeded 1s timeout.")
+
+        with (
+            patch("agent.batch.get_runtime", return_value=mock_rt),
+            patch("agent.batch.run_simple", side_effect=_slow_run),
+            patch("agent.batch.signal.signal"),
+            patch("agent.batch.signal.alarm"),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            run_batch("do something", output_path=str(output_file), timeout=1)
+
+        assert exc_info.value.code == 1
+        parsed = json.loads(output_file.read_text())
+        assert parsed["success"] is False
+        assert "timeout" in parsed["error"].lower()


### PR DESCRIPTION
## Summary

Adds `run` subcommand for non-interactive batch execution.

### Usage
```bash
# Direct task
python chat.py run --task 'summarize this' --output result.json

# Stdin
echo 'summarize this' | python chat.py run --task - --output result.json

# With timeout
python chat.py run --task 'do stuff' --timeout 60
```

### Output (JSON)
```json
{
  "success": true,
  "result": "...",
  "error": null,
  "approval_rounds": 0,
  "elapsed_seconds": 1.234
}
```

### Key decisions
- Reuses `run_simple()` for auto-approval (no cryptographic approval needed)
- Skips DBOS init and approval key unlock in batch mode
- Exit code 0 = success, 1 = failure
- SIGALRM-based timeout (Unix)

### Files changed
- `agent/batch.py` — new batch execution module
- `chat.py` — `run` subcommand + --task/--output/--timeout args
- `tests/test_batch.py` — 7 tests
- `specs/modules/chat.md` — spec updated
- `.github/workflows/ci.yml` — source_to_spec mapping

Closes #138