### PR TITLE
fix(chat): scope strict tool schemas by provider and harden DBOS error path

### DIFF
--- a/specs/modules/chat.md
+++ b/specs/modules/chat.md
@@ -8,7 +8,7 @@ split into focused companion modules.
 
 ## Status
 
-- **Last updated:** 2026-02-16 (Issue #76)
+- **Last updated:** 2026-02-16 (Issue #141)
 - **Source:** `chat.py`, `chat_runtime.py`, `model_resolution.py`, `toolset_builder.py`, `chat_worker.py`, `chat_approval.py`, `chat_cli.py`
 
 ## File Structure
@@ -73,8 +73,8 @@ split into focused companion modules.
   (write approval) + skills toolset from shipped and custom directories.
   Custom skills override shipped skills when names collide.
 - `chat_runtime.build_agent(provider, name, toolsets, system_prompt, options)` — Anthropic/OpenRouter factory
-  that resolves model fallback, strict tool preparation, history processors, and model settings.
-- `toolset_builder.strict_tool_definitions(...)` — marks the first `_MAX_STRICT_TOOLS` (20) tools `strict=True` for OpenAI-compatible providers; remaining tools stay non-strict to respect Anthropic's limit
+  that resolves model fallback, provider-specific tool preparation, history processors, and model settings.
+- `toolset_builder.strict_tool_definitions(...)` — marks the first `_MAX_STRICT_TOOLS` (20) tools `strict=True`; this callback is applied only when the selected provider is `openrouter`
 - `chat_runtime.instrument_agent(agent)` — Enables OpenTelemetry instrumentation when
   `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Returns `True` if applied.
 
@@ -183,6 +183,12 @@ split into focused companion modules.
 
 ## Change Log
 
+- 2026-02-16: `build_agent()` now applies strict tool schema preparation only for
+  `AI_PROVIDER=openrouter`. Anthropic runs without strict tool forcing to avoid
+  provider-side schema compilation failures with larger toolsets. Worker execution
+  now wraps `AgentRunError` as a built-in `RuntimeError` before returning across
+  DBOS workflow boundaries, preventing `ModelHTTPError` pickle deserialization
+  failures in `handle.get_result()`. (Issue #141)
 - 2026-02-16: OTEL insecure flag made configurable via
   `OTEL_EXPORTER_OTLP_INSECURE` env var (Issue #82)
 - 2026-02-16: Headless passphrase support via `APPROVAL_KEY_PASSPHRASE`

--- a/tests/test_chat_runtime.py
+++ b/tests/test_chat_runtime.py
@@ -211,6 +211,23 @@ class TestBuildAgent:
                 build_agent("anthropic", "test", [], "prompt")
 
 
+class TestPrepareToolsForProvider:
+    """Tests for provider-specific tool preparation selection."""
+
+    def test_openrouter_uses_strict_tool_preparation(self) -> None:
+        from agent.runtime import prepare_tools_for_provider
+        from toolset_builder import strict_tool_definitions
+
+        prepare = prepare_tools_for_provider("openrouter")
+        assert prepare is strict_tool_definitions
+
+    def test_anthropic_disables_tool_preparation(self) -> None:
+        from agent.runtime import prepare_tools_for_provider
+
+        prepare = prepare_tools_for_provider("anthropic")
+        assert prepare is None
+
+
 class TestRuntimeRegistry:
     """Tests for lock-protected runtime registry injection and wrappers."""
 

--- a/tests/test_worker_error_wrapping.py
+++ b/tests/test_worker_error_wrapping.py
@@ -1,0 +1,75 @@
+"""Tests for worker error wrapping across the DBOS workflow boundary."""
+
+from __future__ import annotations
+
+import pickle
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic_ai.exceptions import ModelHTTPError
+from pydantic_ai_backends import LocalBackend
+
+import agent.worker as chat_worker
+from models import WorkItem, WorkItemInput, WorkItemPriority, WorkItemType
+from store.history import init_history_store
+
+
+@dataclass
+class _FailingAgent:
+    name: str | None = "test-agent"
+
+    def run_sync(
+        self,
+        prompt: str | None,
+        *,
+        deps: Any,
+        message_history: list[Any],
+        output_type: list[type[Any]],
+        deferred_tool_results: Any,
+    ) -> Any:
+        del prompt, deps, message_history, output_type, deferred_tool_results
+        raise ModelHTTPError(
+            status_code=400,
+            model_name="anthropic:claude-3-5-sonnet-latest",
+            body={"error": {"message": "Schema is too complex for compilation."}},
+        )
+
+
+@dataclass
+class _FakeRuntime:
+    agent: Any
+    backend: LocalBackend
+    history_db_path: str
+    approval_store: Any = None
+    key_manager: Any = None
+    tool_policy: Any = None
+
+
+def test_run_agent_step_wraps_model_http_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run_agent_step should raise RuntimeError rather than ModelHTTPError."""
+    history_db = tmp_path / "history.sqlite"
+    init_history_store(str(history_db))
+    runtime = _FakeRuntime(
+        agent=_FailingAgent(),
+        backend=LocalBackend(root_dir=str(tmp_path), enable_execute=False),
+        history_db_path=str(history_db),
+    )
+    monkeypatch.setattr(chat_worker, "get_runtime", lambda: runtime)
+
+    item = WorkItem(
+        id="work-item-error",
+        type=WorkItemType.CHAT,
+        priority=WorkItemPriority.CRITICAL,
+        input=WorkItemInput(prompt="hello"),
+    )
+
+    with pytest.raises(RuntimeError, match="ModelHTTPError") as exc_info:
+        chat_worker.run_agent_step(item.model_dump(mode="json"))
+
+    restored = pickle.loads(pickle.dumps(exc_info.value))
+    assert "ModelHTTPError" in str(restored)


### PR DESCRIPTION
## Summary
This PR fixes two linked runtime failures when `AI_PROVIDER=anthropic`:

1. Anthropic request failures from overly complex tool schema compilation.
2. DBOS workflow result deserialization crashes when `ModelHTTPError` crosses the workflow boundary.

### What changed
- Added provider-specific tool preparation selection in `agent/runtime.py`.
  - `openrouter` keeps strict tool preparation.
  - `anthropic` no longer forces strict tool definitions.
- Wrapped worker-side `AgentRunError` exceptions into built-in `RuntimeError` before DBOS serialization in `agent/worker.py`.
- Added regression tests:
  - provider-specific tool prep behavior (`tests/test_chat_runtime.py`)
  - worker error wrapping + pickle round-trip safety (`tests/test_worker_error_wrapping.py`)
- Updated `specs/modules/chat.md` behavior notes and changelog.

Closes #141

## Validation
- `uv run ruff check .`
- `uv run pyright`
- `uv run pytest`

All passed locally.
