### PR TITLE
docs: rewrite developer documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,150 +4,130 @@
 
 Autopoiesis is a durable CLI chat agent built on **PydanticAI** + **DBOS**.
 User messages become work items on a priority queue. A DBOS worker executes
-each item by running a PydanticAI agent with filesystem, shell, memory, and
-subscription tools. Cryptographic approval gates shell execution and filesystem
-operations (exec_tool, process_tool); memory and subscription DB operations do
-not require approval.
-Responses stream back to a Rich terminal UI in real time.
+each item by running a PydanticAI agent with shell, knowledge, topic, subscription,
+and skill tools. Cryptographic approval gates dangerous operations.
+Responses stream back to a Rich terminal UI.
 
 ## System Diagram
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│  chat.py  (entrypoint)                                      │
-│  ┌─────────────┐  ┌──────────────┐  ┌───────────────────┐  │
-│  │ agent/cli    │→│ agent/worker │→│  agent/runtime     │  │
-│  │ (REPL loop)  │  │ (DBOS queue) │  │  (agent builder)  │  │
-│  └──────┬───────┘  └──────┬───────┘  └────────┬──────────┘  │
-│         │                 │                    │             │
-│         ▼                 ▼                    ▼             │
-│  ┌─────────────┐  ┌──────────────┐  ┌───────────────────┐  │
-│  │ display/     │  │ approval/    │  │ toolset_builder   │  │
-│  │ streaming    │  │ (crypto gate)│  │ (tool wiring)     │  │
-│  └─────────────┘  └──────────────┘  └────────┬──────────┘  │
-│                                               │             │
-│                    ┌──────────────────────────┬┘            │
-│                    ▼              ▼           ▼             │
-│             ┌───────────┐ ┌───────────┐ ┌──────────┐       │
-│             │ tools/     │ │ store/    │ │ skills   │       │
-│             │ exec,proc  │ │ mem,hist  │ │ subs     │       │
-│             └───────────┘ └───────────┘ └──────────┘       │
-└─────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│  chat.py  (entrypoint)                                       │
+│  ┌────────────┐  ┌───────────────┐  ┌──────────────────┐    │
+│  │ agent/cli  │→│ agent/worker  │→│ agent/runtime    │    │
+│  │ (REPL)     │  │ (DBOS queue)  │  │ (agent builder)  │    │
+│  └─────┬──────┘  └──────┬────────┘  └───────┬──────────┘    │
+│        │                │                    │               │
+│        ▼                ▼                    ▼               │
+│  ┌───────────┐  ┌──────────────┐  ┌──────────────────┐      │
+│  │ display/  │  │ approval/    │  │ toolset_builder  │      │
+│  │ streaming │  │ (crypto gate)│  │ (tool wiring)    │      │
+│  └───────────┘  └──────────────┘  └────────┬─────────┘      │
+│                                            │                │
+│                 ┌──────────┬───────────────┼────────┐       │
+│                 ▼          ▼               ▼        ▼       │
+│          ┌──────────┐ ┌────────┐ ┌──────────┐ ┌────────┐   │
+│          │ shell    │ │ know-  │ │ topics/  │ │ skills │   │
+│          │ tool     │ │ ledge  │ │ subs     │ │        │   │
+│          └──────────┘ └────────┘ └──────────┘ └────────┘   │
+└──────────────────────────────────────────────────────────────┘
 ```
+
+## Tool Inventory
+
+| Tool | Module | Approval | Purpose |
+|------|--------|----------|---------|
+| **shell** | `tools/shell_tool.py` | Yes | Single `shell(command)` interface replacing exec+process. Commands classified into security tiers. |
+| **knowledge** | `tools/memory_tools.py` | No | FTS5-backed persistent memory: write, search, auto-load, delete |
+| **topics** | `tools/subscription_tools.py` | No | Topic lifecycle: activate, deactivate, status transitions |
+| **subscriptions** | `tools/subscription_tools.py` | No | File/topic subscriptions for reactive context injection |
+| **skills** | `skills.py` | No | Filesystem skill discovery, progressive disclosure |
+| **skillmaker** | `skillmaker_tools.py` | No | Validate and lint skill files |
+
+### Shell Command Classification
+
+The shell tool classifies commands into security tiers via `infra/command_classifier.py`:
+
+| Tier | Approval | Examples |
+|------|----------|---------|
+| **FREE** | None | `ls`, `cat`, `git status`, `find` |
+| **REVIEW** | User reviews | `git commit`, `pip install` |
+| **APPROVE** | Explicit sign | `rm`, `curl \| sh`, write operations |
+| **BLOCK** | Denied | `sudo`, commands with `&&` chaining dangerous ops |
+
+## Agent Tiers
+
+The WorkItem queue supports a three-tier agent hierarchy:
+
+| Tier | Role | Description |
+|------|------|-------------|
+| **T1** | Human | The user. Issues commands, approves operations. |
+| **T2** | Planner / Orchestrator | Decomposes tasks, creates WorkItems for T3 agents. Routes via topics. |
+| **T3** | Workers | Execute scoped tasks (code, review, research). Isolated workspaces. |
+
+Currently T1→T3 (direct CLI) is the primary path. T2 orchestration and T3 multi-agent flows are being built (see WorkItem 3-Tier Flow in tests).
+
+## Multi-Agent Coordination
+
+### WorkItems
+
+Every unit of work is a `WorkItem` on a DBOS priority queue (`infra/work_queue.py`). Priority levels: `CRITICAL` → `HIGH` → `NORMAL` → `LOW` → `IDLE`.
+
+### Agent Isolation
+
+Each agent gets its own workspace, history, and tool context. Agents cannot see each other's state. Isolation is enforced at the runtime level.
+
+### Topic Routing
+
+Topics enable inter-agent communication:
+- An agent activates a topic → subscribes to updates
+- WorkItems can be routed to topic owners
+- Owner-based triggers fire when relevant work arrives
 
 ## Data Flow: One Chat Turn
 
-1. **User types** a message at the `>` prompt in `agent/cli.py`
-2. `_run_turn()` wraps it in a `WorkItem` (type=CHAT, priority=CRITICAL)
-3. A `RichStreamHandle` is registered for the item's id in `display/streaming.py`
-4. `enqueue_and_wait()` puts the item on the DBOS `infra/work_queue`
-5. DBOS dispatches `execute_work_item()` → `run_agent_step()` in `agent/worker.py`
-6. Worker deserializes history, builds `AgentDeps`, constructs `ApprovalScope`
-7. `rt.agent.run_stream_sync()` calls the PydanticAI agent with all toolsets
-8. Tokens stream through `StreamHandle.write()` → `RichDisplayManager` → terminal
-9. If a tool needs approval → agent returns `DeferredToolRequests`, CLI prompts user, re-enqueues
-10. On completion, `WorkItemOutput` (text + serialized history) returns to CLI
-11. History JSON is carried forward for the next turn
-
-## Module Dependency Graph
-
-```mermaid
-graph TD
-    chat.py --> agent/cli.py
-    chat.py --> agent/runtime.py
-    chat.py --> agent/worker.py
-    chat.py --> toolset_builder.py
-    chat.py --> model_resolution.py
-    chat.py --> approval/keys.py
-    chat.py --> approval/store.py
-    chat.py --> store/history.py
-    chat.py --> store/memory.py
-
-    agent/cli.py --> agent/worker.py
-    agent/cli.py --> approval/chat_approval.py
-    agent/cli.py --> display/streaming.py
-
-    agent/worker.py --> agent/runtime.py
-    agent/worker.py --> approval/chat_approval.py
-    agent/worker.py --> store/history.py
-    agent/worker.py --> display/streaming.py
-    agent/worker.py --> display/stream_formatting.py
-
-    agent/runtime.py --> toolset_builder.py
-    agent/runtime.py --> model_resolution.py
-    agent/runtime.py --> models.py
-
-    toolset_builder.py --> prompts.py
-    toolset_builder.py --> tools/memory_tools.py
-    toolset_builder.py --> skills.py
-    toolset_builder.py --> tools/subscription_tools.py
-    toolset_builder.py --> tools/exec_tool.py
-    toolset_builder.py --> tools/process_tool.py
-    toolset_builder.py --> tools/toolset_wrappers.py
-
-    approval/store.py --> approval/crypto.py
-    approval/store.py --> approval/types.py
-    approval/store.py --> approval/store_schema.py
-    approval/store.py --> approval/store_verify.py
-    approval/keys.py --> approval/key_files.py
-    approval/keys.py --> approval/crypto.py
-
-    tools/exec_tool.py --> infra/exec_registry.py
-    tools/exec_tool.py --> infra/pty_spawn.py
-    tools/exec_tool.py --> io_utils.py
-
-    tools/memory_tools.py --> store/memory.py
-    tools/subscription_tools.py --> store/subscriptions.py
-    infra/subscription_processor.py --> store/subscriptions.py
-```
-
-## Package Responsibilities
-
-| Cluster | Files | What it does |
-|---------|-------|-------------|
-| **Entry & CLI** | `chat.py`, `agent/cli.py` | Arg parsing, env loading, DBOS bootstrap, interactive REPL |
-| **Agent Runtime** | `agent/runtime.py`, `agent/worker.py`, `models.py`, `infra/work_queue.py` | Agent construction, DBOS queue worker, work item types, priority queue |
-| **Tool Wiring** | `toolset_builder.py`, `tools/toolset_wrappers.py`, `prompts.py` | Assembles all toolsets, composes system prompt, observable wrappers |
-| **Exec Tools** | `tools/exec_tool.py`, `tools/process_tool.py`, `infra/exec_registry.py`, `infra/pty_spawn.py`, `io_utils.py` | Shell execution with PTY, process management, session tracking |
-| **Memory** | `tools/memory_tools.py`, `store/memory.py` | FTS5-backed persistent memory, search/save/get tools |
-| **Skills** | `skills.py`, `skillmaker_tools.py` | Filesystem skill discovery, progressive disclosure, skill linting |
-| **Subscriptions** | `tools/subscription_tools.py`, `store/subscriptions.py`, `infra/subscription_processor.py` | Reactive context injection, subscription registry, history materialization |
-| **Approval** | `approval/types.py`, `approval/crypto.py`, `approval/keys.py`, `approval/key_files.py`, `approval/policy.py`, `approval/store.py`, `approval/store_schema.py`, `approval/store_verify.py`, `approval/chat_approval.py` | Cryptographic tool approval with Ed25519 signing, envelope storage, policy |
-| **Persistence** | `store/history.py`, `store/memory.py`, `db.py` | SQLite checkpoint store, memory FTS5 store, shared DB helpers |
-| **Display** | `display/streaming.py`, `display/rich_display.py`, `display/stream_formatting.py` | Real-time Rich terminal UI, stream handles, event formatting |
-| **Context** | `agent/context.py`, `agent/truncation.py` | Token-based history compaction, oversized tool result truncation |
-| **Model** | `model_resolution.py` | Provider/model resolution (Anthropic, OpenRouter) |
-| **Observability** | `infra/otel_tracing.py` | OpenTelemetry span creation and configuration |
-| **Utility** | `run_simple.py` | Convenience auto-approve wrapper for scripted runs |
+1. User types at `>` prompt → `agent/cli.py`
+2. Wrapped in `WorkItem(type=CHAT, priority=CRITICAL)`
+3. Enqueued on DBOS work queue
+4. Worker dispatches → `run_agent_step()` builds agent with tools
+5. PydanticAI streams response → Rich terminal UI
+6. Tool calls requiring approval → `DeferredToolRequests` → CLI prompts user
+7. Completed `WorkItemOutput` (text + history) returns to CLI
 
 ## Key Design Decisions
 
 ### Single DBOS Queue
-All work (chat, exec callbacks, future task types) flows through one priority
-queue (`infra/work_queue.py`). Priority levels (`CRITICAL` to `IDLE`) control
-ordering. This keeps the execution model simple and durable — DBOS handles
-retries and persistence.
+All work flows through one priority queue. DBOS handles retries and persistence. Simple and durable.
 
 ### Cryptographic Approval
-Shell execution and filesystem operations (via `tools/exec_tool` and `tools/process_tool`)
-require Ed25519-signed approval envelopes. Memory and subscription tools
-operate on local SQLite databases and are wired without approval predicates.
-The user unlocks their signing key at startup; the CLI prompts per-tool-call.
-Approvals are stored in SQLite with nonce-based replay protection. This is a
-real security boundary, not just a confirmation dialog.
+Shell and file operations require Ed25519-signed envelopes with nonce-based replay protection. This is a real security boundary, not a confirmation dialog.
 
 ### Flat Entry Point
-`chat.py` is the single `main()`. It wires everything — env, backend, tools,
-agent, DBOS, CLI — in one linear sequence. No framework magic, no plugin
-discovery. You read `chat.py` and you see the full startup.
+`chat.py` is the single `main()`. No framework magic, no plugin discovery. Read it and see the full startup.
 
-### Ephemeral Streams
-`StreamHandle` instances live in-process only. They are NOT serialized or
-persisted. Durability comes from the final `WorkItemOutput` written after
-each turn. Streams are a convenience layer for real-time terminal display.
+### File-First Philosophy
+- **Specs** are markdown files in `specs/modules/`
+- **Skills** are markdown files in `skills/`
+- **Knowledge** is searchable text in SQLite FTS5
+- **Configuration** is `.env` + minimal frontmatter
+- Everything version-controlled in git
 
-### Filesystem Skills
-Skills are `.md` files in a directory. The agent discovers them at startup via
-`SkillDirectory`. No registration, no imports — just drop a `SKILL.md` file.
-Custom skills go in the workspace; shipped skills live in the repo `skills/`
-directory.
+### Plan System (Upcoming)
+Contract-based plan execution with hard verification. Plans define expected outcomes; the system verifies them programmatically, not by asking the LLM "did you do it?". See `docs/research/plan-system-design.md`.
+
+## Package Responsibilities
+
+| Cluster | Key Files | Purpose |
+|---------|-----------|---------|
+| **Entry & CLI** | `chat.py`, `agent/cli.py` | Env loading, DBOS bootstrap, REPL |
+| **Agent Runtime** | `agent/runtime.py`, `agent/worker.py`, `infra/work_queue.py` | Agent construction, queue worker, work items |
+| **Tool Wiring** | `toolset_builder.py`, `tools/toolset_wrappers.py`, `prompts.py` | Assembles toolsets, composes system prompt |
+| **Shell** | `tools/shell_tool.py`, `infra/command_classifier.py`, `infra/audit_log.py` | Unified shell interface, command classification, audit trail |
+| **Knowledge** | `tools/memory_tools.py`, `store/memory.py` | FTS5-backed persistent memory |
+| **Skills** | `skills.py`, `skillmaker_tools.py` | Filesystem skill discovery, validation |
+| **Subscriptions** | `tools/subscription_tools.py`, `store/subscriptions.py`, `infra/subscription_processor.py` | Reactive context injection |
+| **Approval** | `approval/` | Ed25519 signing, envelope storage, policy |
+| **Persistence** | `store/history.py`, `db.py` | SQLite checkpoint store, shared DB helpers |
+| **Display** | `display/` | Rich terminal UI, streaming |
+| **Context** | `agent/context.py`, `agent/truncation.py` | History compaction, result truncation |
+| **Observability** | `infra/otel_tracing.py` | OpenTelemetry spans |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,83 +2,86 @@
 
 ## For AI Agents
 
-Read `AGENTS.md` first — it has project-specific rules that override general
-knowledge. Use the **File Map** to navigate; don't read the whole codebase.
+Read `AGENTS.md` first — it has project-specific rules that override general knowledge.
 
 ---
 
 ## Prerequisites
 
 - **Python 3.12+**
-- **[uv](https://docs.astral.sh/uv/)** (package manager — no pip, no poetry)
+- **[uv](https://docs.astral.sh/uv/)** — package manager (no pip, no poetry)
 - **git**
 
-## 5-Minute Setup
+## Setup
 
 ```bash
-# 1. Clone and enter
 git clone https://github.com/DavSimFel/autopoiesis.git
 cd autopoiesis
-
-# 2. Install dependencies
 uv sync
-
-# 3. Configure environment
-cp .env.example .env
-# Edit .env — set AI_PROVIDER and API keys
-
-# 4. Verify everything works
-uv run ruff check .
-uv run ruff format --check .
-uv run pyright
-uv run pytest
-
-# 5. Run
-uv run python chat.py
+cp .env.example .env   # set AI_PROVIDER and API keys
+uv run pytest           # verify everything works
 ```
 
-## Project Map
+---
 
-Source is organized into subdirectory packages. Root-level files handle
-entry point wiring and shared utilities.
+## Core Workflow: Specs and Tests
 
-| Area | Files |
-|------|-------|
-| Entry point | `chat.py` |
-| CLI loop | `agent/cli.py` |
-| Agent builder | `agent/runtime.py` |
-| Queue worker | `agent/worker.py` |
-| Context mgmt | `agent/context.py`, `agent/truncation.py` |
-| Tool wiring | `toolset_builder.py`, `tools/toolset_wrappers.py` |
-| System prompt | `prompts.py` |
-| Core types | `models.py`, `infra/work_queue.py` |
-| Exec tools | `tools/exec_tool.py`, `tools/process_tool.py`, `infra/exec_registry.py`, `infra/pty_spawn.py` |
-| Memory tools | `tools/memory_tools.py`, `store/memory.py` |
-| Skills | `skills.py`, `skillmaker_tools.py` |
-| Subscriptions | `tools/subscription_tools.py`, `store/subscriptions.py`, `infra/subscription_processor.py` |
-| Approval system | `approval/` (types, crypto, keys, key_files, policy, store, chat_approval) |
-| Persistence | `store/history.py`, `db.py` |
-| Display | `display/streaming.py`, `display/rich_display.py`, `display/stream_formatting.py` |
-| Model resolution | `model_resolution.py` |
-| Observability | `infra/otel_tracing.py` |
-| Specs | `specs/` (module specs, decisions, template) |
-| Tests | `tests/` |
+**Developer control happens through specs and tests.** Code is written by agents, verified by CI, approved by humans.
 
-## "I Want To..." Quick Reference
+### Specs
 
-| I want to... | Do this |
-|---------------|---------|
-| Add a new tool | Follow `tools/_PATTERN.md` |
-| Change the system prompt | Edit `prompts.py`, check `toolset_builder.py` for composition |
-| Add a provider | Edit `model_resolution.py` |
-| Fix a test | Find matching `tests/test_*.py`, run `uv run pytest tests/test_foo.py -x` |
-| Add a dependency | Edit `pyproject.toml`, run `uv sync`, get explicit approval first |
-| Understand the architecture | Read `ARCHITECTURE.md` |
-| Find where something lives | Use the File Map in `AGENTS.md` |
+Every module has a spec in `specs/modules/*.md`. Specs define:
+- What the module does (contract)
+- Public API surface
+- Invariants that must hold
 
-## First PR Walkthrough
+**When you change behavior → update the spec.** New module → create spec from `specs/_template.md`. Architecture changes → ADR in `specs/decisions/`.
 
-### 1. Branch
+CI runs `spec-check` to verify specs stay in sync with code.
+
+### Tests
+
+Tests are the executable version of specs. See **[docs/testing.md](docs/testing.md)** for the complete guide.
+
+```bash
+uv run pytest                          # all tests
+uv run pytest tests/integration/       # integration only
+uv run pytest tests/test_knowledge.py  # single file
+uv run pytest -x                       # stop on first failure
+uv run pytest -k "test_startup"        # by name pattern
+```
+
+### xfail and skip Conventions
+
+- **`xfail`** = spec for an unimplemented feature. The test documents intended behavior; it's expected to fail until implemented.
+- **`skip`** = blocked on an external dependency or unmerged PR. Can't run yet.
+
+Both are legitimate. Neither should be used to hide broken code.
+
+---
+
+## CI Pipeline
+
+Every PR runs 7 checks:
+
+| Check | What it does |
+|-------|-------------|
+| **lint** | `ruff check .` — style and import rules |
+| **format** | `ruff format --check .` — code formatting |
+| **typecheck** | `pyright` — strict type checking |
+| **test** | `pytest` — all tests must pass |
+| **security** | Dependency and secret scanning |
+| **narrative** | Checks narrative docs are current |
+| **arch-check** | Validates architecture constraints |
+| **spec-check** | Verifies specs match implementation |
+
+All must be green before merge.
+
+---
+
+## Git Workflow
+
+### Branch
 
 ```bash
 git checkout main && git pull
@@ -88,91 +91,67 @@ git checkout -b feat/issue-42-add-widget
 Branch format: `{type}/issue-{number}-{slug}`
 Types: `feat`, `fix`, `chore`, `refactor`, `docs`
 
-### 2. Implement
-
-- Keep changes scoped to one logical concern
-- Follow the code style below
-- Update specs in `specs/modules/` if behavior changed
-- New modules get a spec from `specs/_template.md`
-
-### 3. Verify
+### Commit
 
 ```bash
-uv run ruff check .           # lint
-uv run ruff format --check .  # formatting
-uv run pyright                # type checking
-uv run pytest                 # tests
-```
-
-All four must pass. No exceptions.
-
-### 4. Commit
-
-```bash
-git add -A
 git commit -m "feat(chat): add widget support (#42)"
 ```
 
 Format: `type(scope): description (#issue)`
 
-### 5. Push & PR
+### PR
 
-```bash
-git push -u origin feat/issue-42-add-widget
-```
+Push to origin, open PR to `main`. Squash merge after approval.
 
-Open a PR to `main`. Fill in the PR template. Reference the issue.
+### Review Process
 
-### 6. Review
+1. **Agents write code** on feature branches
+2. **CI verifies** — all 7 checks must pass
+3. **Human approves** — David has final say on `main`
 
-- AI agents review each other's PRs
-- David has final approval on `main`
-- Address all feedback before re-requesting review
+---
 
-## Code Style Essentials
+## Code Style
 
 | Rule | Detail |
 |------|--------|
 | **Typing** | Strict pyright. Every parameter and return typed. No `Any` without justification. |
 | **Naming** | `snake_case` functions/vars, `PascalCase` classes, `UPPER_SNAKE` constants |
-| **Imports** | stdlib → third-party → local, separated by blank lines. No wildcard imports. |
+| **Imports** | stdlib → third-party → local, separated by blank lines. No wildcards. |
 | **Docstrings** | Google style. Required on all public functions/classes. |
 | **Comments** | Explain WHY, never WHAT. No commented-out code. |
-| **File limit** | 300 lines max per file |
-| **Function limit** | 50 lines max per function |
-| **Complexity** | Max cyclomatic complexity: 10 |
+| **File limit** | 300 lines max |
+| **Function limit** | 50 lines max |
+| **Suppressions** | No `# noqa`, no `# type: ignore`. Fix the code. |
 | **TODOs** | Must reference an issue: `# TODO(#42): description` |
-| **Suppressions** | No `# noqa`, no `# type: ignore`, no pyright ignore directives. Fix the code. |
-
-## Spec Requirements
-
-Every PR that changes behavior **must** update specs:
-
-- Modified module → update its spec in `specs/modules/`
-- New module → create spec from `specs/_template.md`
-- Architecture change → ADR in `specs/decisions/`
-- System-level change → update `specs/OVERVIEW.md`
-- Always add a changelog entry with date and PR/issue number
 
 ## What Gets Your PR Rejected
 
-1. Any lint/type suppression (`# noqa`, type-ignore, pyright ignore)
-2. Weakening lint rules to make CI pass
-3. Files over 300 lines
-4. Functions over 50 lines
-5. Dead code (commented-out blocks, unused imports)
-6. TODOs without issue links
-7. Bare `except:` or `except Exception:` without specific handling
-8. Hardcoded secrets or environment-specific values
-9. `print()` for debugging (use `logging`)
-10. Untyped parameters or return values
-11. Magic numbers without named constants
-12. Adding deps for trivial functionality
-13. Mixing concerns in one PR (feature + refactor + fix)
-14. Swallowed errors (`except: pass`)
-15. Copy-paste duplication
-16. Missing docstrings on public functions/classes
-17. Test files without assertions
-18. Changes outside the scope of the issue
-19. Missing spec updates for behavior changes
-20. Skipping CI checks locally before pushing
+1. Lint/type suppressions
+2. Files over 300 lines or functions over 50 lines
+3. Dead code, unused imports, bare `except:`
+4. Missing specs for behavior changes
+5. Hardcoded secrets
+6. `print()` debugging (use `logging`)
+7. Missing docstrings on public API
+8. Mixing concerns in one PR
+9. Skipping CI checks locally
+
+---
+
+## Project Map
+
+| Area | Files |
+|------|-------|
+| Entry point | `chat.py` |
+| CLI loop | `agent/cli.py` |
+| Agent builder | `agent/runtime.py` |
+| Queue worker | `agent/worker.py` |
+| Tool wiring | `toolset_builder.py`, `tools/toolset_wrappers.py` |
+| Shell tool | `tools/shell_tool.py`, `infra/command_classifier.py` |
+| Memory tools | `tools/memory_tools.py`, `store/memory.py` |
+| Skills | `skills.py`, `skillmaker_tools.py` |
+| Subscriptions | `tools/subscription_tools.py`, `store/subscriptions.py` |
+| Approval | `approval/` |
+| Tests | `tests/`, `tests/integration/` |
+| Specs | `specs/modules/` |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,147 @@
+# Testing Guide
+
+## Running Tests
+
+```bash
+uv run pytest                              # everything
+uv run pytest tests/                       # unit tests
+uv run pytest tests/integration/           # integration tests
+uv run pytest tests/test_knowledge.py      # single file
+uv run pytest -x                           # stop on first failure
+uv run pytest -k "test_startup"            # by name pattern
+uv run pytest -v                           # verbose output
+```
+
+## Test Structure
+
+```
+tests/
+├── conftest.py                  # shared fixtures
+├── test_*.py                    # unit tests (~30 files)
+└── integration/
+    ├── conftest.py              # integration fixtures (server lifecycle, etc.)
+    ├── test_startup.py          # S1: Startup & Serve
+    ├── test_agent_isolation.py  # S2: Agent Isolation
+    ├── test_history.py          # S3: History & Recovery
+    ├── test_skills.py           # S4: Skill Loading
+    ├── test_shell_tool.py       # S5: Shell Tool
+    ├── test_command_classification.py  # S6: Command Classification
+    ├── test_toolset_assembly.py # S7: Toolset Assembly
+    ├── test_knowledge.py        # S8: Knowledge System
+    ├── test_topic_lifecycle.py  # S9: Topic Lifecycle
+    ├── test_subscriptions.py    # S10: Subscription Pipeline
+    ├── test_topic_routing.py    # S11: Topic Routing
+    └── test_workitem_flow.py    # S12: WorkItem 3-Tier Flow
+```
+
+## Integration Test Tiers
+
+### Tier 1 — Foundation
+
+| Section | Tests | Status | What it tests |
+|---------|-------|--------|---------------|
+| **S1: Startup & Serve** | 7 | ✅ All green | Server boots, batch mode works, health endpoint responds |
+| **S2: Agent Isolation** | 6 | 3 skip | Agents can't see each other's history, workspace, or tools |
+| **S3: History & Recovery** | 5 | ✅ All green | Chat state survives restarts, history checkpoint round-trips |
+| **S4: Skill Loading** | 4 | ✅ All green | Skills discovered from filesystem, custom overrides shipped |
+
+### Tier 2 — Shell & Security
+
+| Section | Tests | Status | What it tests |
+|---------|-------|--------|---------------|
+| **S5: Shell Tool** | 10 | New | Single `shell(command)` interface, output capture, timeout handling |
+| **S6: Command Classification** | 10 | New | Security tier assignment (FREE/REVIEW/APPROVE/BLOCK) for commands |
+| **S7: Toolset Assembly** | 5 | New | All tools register correctly, no missing/duplicate registrations |
+
+### Tier 3 — Content & Context
+
+| Section | Tests | Status | What it tests |
+|---------|-------|--------|---------------|
+| **S8: Knowledge System** | 4 | ✅ All green | Write entries, FTS5 search, auto-load on relevance, delete |
+| **S9: Topic Lifecycle** | 9 | ✅ All green | Activate/deactivate topics, status transitions, edge cases |
+| **S10: Subscription Pipeline** | 5 | 1 skip | File and topic subscriptions fire, context injection works |
+
+### Tier 4 — Multi-Agent Coordination
+
+| Section | Tests | Status | What it tests |
+|---------|-------|--------|---------------|
+| **S11: Topic Routing** | 6 | 4 skip | WorkItems route to topic owners, owner-based triggers fire |
+| **S12: WorkItem 3-Tier Flow** | 5 | All skip | Planner creates WorkItems → Coder executes → Reviewer validates |
+
+### Current Totals
+
+- **38 green** — passing reliably
+- **13 skip** — blocked on dependencies or unmerged work
+- **25 incoming** — shell/security tests (Tier 2)
+
+## xfail and skip Conventions
+
+### `@pytest.mark.xfail`
+
+Marks a test for a feature that **should work but doesn't yet**. The test documents the intended behavior as a spec. When the feature is implemented and the test starts passing, pytest will notify you to remove the xfail marker.
+
+```python
+@pytest.mark.xfail(reason="WorkItem routing not yet implemented (#123)")
+def test_workitem_routes_to_topic_owner():
+    ...
+```
+
+### `@pytest.mark.skip`
+
+Marks a test that **cannot run** due to an external dependency (unmerged PR, missing infrastructure, etc.).
+
+```python
+@pytest.mark.skip(reason="Blocked on shell tool PR #171")
+def test_shell_command_classification():
+    ...
+```
+
+**Neither should be used to hide broken code.** If a previously-passing test breaks, fix the code — don't skip the test.
+
+## Writing New Integration Tests
+
+### Pattern
+
+```python
+"""S8: Knowledge System — write and search."""
+import pytest
+from tests.integration.conftest import some_fixture
+
+class TestKnowledgeWrite:
+    """Group related tests in a class matching the section theme."""
+
+    def test_write_and_search(self, running_server):
+        """One behavior per test. Name says what it verifies."""
+        # Arrange
+        ...
+        # Act
+        result = do_something()
+        # Assert
+        assert result.status == "ok"
+```
+
+### Conventions
+
+1. **One test = one behavior.** Don't test five things in one function.
+2. **Use `running_server` fixture** for tests that need a live server (from `integration/conftest.py`).
+3. **Class grouping** by section theme (e.g., `TestStartup`, `TestKnowledgeSearch`).
+4. **Descriptive names:** `test_<what>_<expected_outcome>` — e.g., `test_search_returns_matching_entries`.
+5. **Follow the test manifest** (issue #154) for section numbering and scope.
+
+## CI
+
+### On Every PR
+
+All 7 CI checks run:
+
+| Check | Command |
+|-------|---------|
+| lint | `uv run ruff check .` |
+| format | `uv run ruff format --check .` |
+| typecheck | `uv run pyright` |
+| test | `uv run pytest` |
+| security | Dependency + secret scanning |
+| arch-check | Architecture constraint validation |
+| spec-check | Spec ↔ implementation sync |
+
+All must pass before merge.


### PR DESCRIPTION
Rewrites all developer-facing documentation to reflect current project state.

## Changes

- **README.md** — rewritten: what autopoiesis is, quick start, verify commands, config table, links to docs
- **CONTRIBUTING.md** — rewritten: specs-and-tests workflow, CI pipeline (7 checks), xfail/skip conventions, code style, PR rejection criteria
- **ARCHITECTURE.md** — rewritten: tool inventory (shell tool, knowledge, topics, subscriptions, skills), agent tiers (T1/T2/T3), multi-agent coordination (WorkItems, isolation, topic routing), plan system (upcoming), file-first philosophy
- **docs/testing.md** — NEW: complete testing guide with all commands, test structure, integration test tiers (S1-S12), current status (38 green, 13 skip, 25 incoming), xfail/skip conventions, how to write new tests, CI details

No code changes.