### PR TITLE
ci: add integration-test-guard job and auto-merge policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,37 @@ jobs:
       - name: Bandit
         run: uv run bandit -r src -s B101 --exclude ./.venv,./tests
 
+  integration-test-guard:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check integration test changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          changed=$(git diff --name-only origin/main...HEAD -- 'tests/integration/')
+          if [ -n "$changed" ]; then
+            echo "::warning::Integration tests modified — human review required"
+            echo "$changed"
+            gh pr edit ${{ github.event.pull_request.number }} --add-label "needs-human-review"
+            # Check if comment already exists to avoid duplicates
+            existing=$(gh pr view ${{ github.event.pull_request.number }} --json comments --jq '.comments[].body' | grep -c "modifies integration tests" || true)
+            if [ "$existing" -eq "0" ]; then
+              gh pr comment ${{ github.event.pull_request.number }} --body "⚠️ **This PR modifies integration tests.** Requires human review before merge.
+
+          Changed files:
+          \`\`\`
+          $changed
+          \`\`\`"
+            fi
+          else
+            echo "No integration test changes."
+          fi
+
   arch-check:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,17 @@ Push to origin, open PR to `main`. Squash merge after approval.
 
 ---
 
-## Code Style
+## Auto-Merge Policy
+
+PRs are subject to the following merge policy:
+
+- **PRs that modify `tests/integration/`** are automatically labeled `needs-human-review` and require human approval before merge. Integration tests define the architecture spec and are controlled by humans.
+- **All other PRs** auto-merge when CI passes.
+- The `integration-test-guard` CI job detects integration test changes and posts a comment — it always passes (advisory, not blocking).
+
+---
+
+## Code Style Essentials
 
 | Rule | Detail |
 |------|--------|


### PR DESCRIPTION
## Changes

- **New CI job:** `integration-test-guard` — detects changes to `tests/integration/` and labels the PR `needs-human-review` with an advisory comment. Always passes (not a gate).
- **Label created:** `needs-human-review` (red, describes integration test requirement)
- **Auto-merge enabled** on the repo
- **CONTRIBUTING.md** updated with auto-merge policy section

## Policy
- PRs touching integration tests → labeled, require human review
- All other PRs → auto-merge when CI green
- Integration tests = architecture spec, human-controlled