### PR TITLE
feat: tier-based approval enforcement + batch mode spec alignment

### DIFF
--- a/specs/modules/chat.md
+++ b/specs/modules/chat.md
@@ -171,9 +171,26 @@ split into focused companion modules.
 10. Agent executes approved tools, gets denial messages for denied ones
 11. Loop repeats until agent returns a final `str` response
 
+## Batch Mode Execution
+
+Batch mode (`run` subcommand) uses direct agent execution via `run_simple()`
+for simplicity. Durability guarantees (crash recovery, retry) do not apply to
+batch runs. This is intentional: batch tasks are single-shot and short-lived;
+the calling process (CI, scripts) handles retry at a higher level.
+
+Batch mode does not require approval key unlock — it operates with
+FREE-tier-only shell access (see `specs/modules/security.md`).
+
+## Security Model
+
+Shell command execution is subject to tier-based enforcement. See
+`specs/modules/security.md` for the full tier enforcement rules, Docker
+exception, and `--no-approval` behavior.
+
 ## Invariants
 
-- All work goes through the queue. No direct `agent.run_sync()` outside workers.
+- All **interactive** work goes through the queue. Batch mode (`run` subcommand)
+  is an intentional exception — it uses direct `run_simple()` / `agent.run_sync()`.
 - All agent calls use `output_type=[str, DeferredToolRequests]`.
 - Required env vars fail with `SystemExit`, not `KeyError`.
 - `.env` loads relative to `src/autopoiesis/cli.py`, not CWD.

--- a/specs/modules/security.md
+++ b/specs/modules/security.md
@@ -1,0 +1,59 @@
+# Module: security
+
+## Purpose
+
+Documents the security model for shell command execution, including Ed25519
+approval signing and tier-based command enforcement.
+
+## Status
+
+- **Last updated:** 2026-02-17
+- **Source:** `specs/security.md` (full approval model), `src/autopoiesis/infra/command_classifier.py`, `src/autopoiesis/tools/shell_tool.py`
+
+## Ed25519 Approval Model
+
+See `specs/security.md` for the complete approval architecture (R1–R13).
+The approval keypair is the root of trust: the CLI requires passphrase
+unlock at startup before any side-effecting tool can execute.
+
+## Tier-Based Command Enforcement
+
+Shell commands are classified into four tiers by `command_classifier.classify()`:
+
+| Tier | Examples | Behavior |
+|------|----------|----------|
+| **FREE** | `ls`, `cat`, `echo`, `grep`, `git status` | Always allowed |
+| **REVIEW** | `pip install`, `git commit` | Requires approval unlock |
+| **APPROVE** | `rm`, `curl`, `git push` | Requires approval unlock |
+| **BLOCK** | `sudo`, `su`, `doas` | Always denied |
+
+### Enforcement rules
+
+1. **Without approval unlock** (`--no-approval` or batch mode): only FREE-tier
+   commands are permitted. REVIEW and APPROVE commands return a blocked
+   `ShellResult` with an informative error message.
+2. **With approval unlock** (normal interactive mode): FREE, REVIEW, and
+   APPROVE commands are permitted. The deferred-tool approval flow (envelope
+   signing) still applies for side-effecting PydanticAI tools.
+3. **BLOCK tier**: always denied regardless of approval state.
+
+### Docker/container exception
+
+When the execution backend is a Docker or container-based sandbox, all tiers
+(except BLOCK) are permitted without approval unlock. The container **is** the
+sandbox — the host is not at risk. This exception is evaluated at the backend
+level, not inside `shell()` itself. Container backends pass
+`approval_unlocked=True` when invoking the shell tool.
+
+### `--no-approval` flag
+
+The `--no-approval` CLI flag allows startup without passphrase unlock. This is
+**not** a full security bypass — it restricts execution to FREE-tier commands
+only. It enables development and read-only workflows without key material.
+
+## Invariants
+
+- BLOCK-tier commands are never executed.
+- Without approval unlock, only FREE-tier commands run.
+- Tier classification is determined by `command_classifier.classify()` and
+  covers chained commands (pipes, `&&`, `||`, `;`) — the worst tier wins.

--- a/tests/test_tier_enforcement.py
+++ b/tests/test_tier_enforcement.py
@@ -1,0 +1,50 @@
+"""Unit tests for tier-based approval enforcement in shell_tool."""
+
+from __future__ import annotations
+
+from autopoiesis.tools.shell_tool import shell
+
+
+def test_free_command_without_approval() -> None:
+    """FREE commands execute when approval is not unlocked."""
+    result = shell("echo hello", approval_unlocked=False)
+    assert not result.blocked
+    assert "hello" in result.stdout
+
+
+def test_review_command_blocked_without_approval() -> None:
+    """REVIEW commands are blocked when approval is not unlocked."""
+    result = shell("git commit --allow-empty -m test", approval_unlocked=False)
+    assert result.blocked
+    assert result.exit_code == 1
+    assert "review" in result.stderr.lower()
+
+
+def test_approve_command_blocked_without_approval() -> None:
+    """APPROVE commands are blocked when approval is not unlocked."""
+    result = shell("git push origin main", approval_unlocked=False)
+    assert result.blocked
+    assert result.exit_code == 1
+    assert "approve" in result.stderr.lower()
+
+
+def test_review_command_allowed_with_approval() -> None:
+    """REVIEW commands execute when approval is unlocked."""
+    result = shell("pip --version", approval_unlocked=True)
+    assert not result.blocked
+
+
+def test_approve_command_allowed_with_approval() -> None:
+    """APPROVE commands execute when approval is unlocked."""
+    # curl --version is classified as APPROVE tier but is safe to run
+    result = shell("curl --version", approval_unlocked=True)
+    assert not result.blocked
+
+
+def test_block_tier_always_blocked() -> None:
+    """BLOCK-tier commands are rejected regardless of approval state."""
+    for unlocked in (True, False):
+        result = shell("sudo ls", approval_unlocked=unlocked)
+        assert result.blocked
+        assert result.exit_code == 1
+        assert "block" in result.stderr.lower()


### PR DESCRIPTION
## Summary

Two design decisions implemented:

### Decision 1: Tier-based approval enforcement (Option C)
- `shell()` now accepts `approval_unlocked: bool` parameter
- Without approval unlock, only FREE-tier commands execute; REVIEW/APPROVE are blocked
- BLOCK tier is always denied regardless of approval state
- Docker/container backends pass `approval_unlocked=True` (container IS the sandbox)
- New `specs/modules/security.md` documents the full tier enforcement model

### Decision 2: Batch mode stays direct (Option A)
- `specs/modules/chat.md` updated: batch mode documented as intentional exception to queue-based execution
- Softened "no direct agent.run_sync() outside workers" invariant to exclude batch mode

### Tests
- 6 new unit tests covering all tier/approval combinations
- All 429 tests pass, plus ruff/pyright clean