### PR TITLE
fix: add build-system for proper package installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "autopoiesis"
 version = "0.1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 [[package]]
 name = "autopoiesis"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
     { name = "fastapi" },


### PR DESCRIPTION
## Problem
`uv sync` warns: "Skipping installation of entry points (project.scripts) because this project is not packaged"

This means `uv run autopoiesis` can't find the CLI entry point.

## Root Cause
Missing `[build-system]` section in `pyproject.toml`. Without it, uv treats the project as non-packaged and skips `[project.scripts]` installation.

## Fix
Added standard setuptools build-system declaration:
```toml
[build-system]
requires = ["setuptools>=68.0"]
build-backend = "setuptools.build_meta"
```

## Verified
- `uv sync` installs the package properly (no skip warning)
- `uv run autopoiesis --no-approval` starts the CLI chat
- Sending a message gets a response from the AI backend