### PR TITLE
fix: server lifecycle — serve mode works without AI runtime (#231)

### DIFF
--- a/specs/modules/chat.md
+++ b/specs/modules/chat.md
@@ -456,3 +456,6 @@ them on `Runtime`.
 ## Loop Guards (#223)
 - run_turn_cli for multi-agent CLI routing
 - Deferred max iterations and timeout in CLI chat loop
+
+## Server Lifecycle (#231)
+- Serve mode: lightweight init path, skips full AI runtime when ANTHROPIC_API_KEY absent


### PR DESCRIPTION
## Changes
- Lightweight init path for `autopoiesis serve`: DBOS first, AI runtime optional
- Catches SystemExit from missing env vars gracefully  
- Server stays alive and serves API requests even without full runtime
- API returns proper 'runtime_uninitialized' error for status endpoint

## Testing
```bash
# Without ANTHROPIC_API_KEY:
autopoiesis serve --port 8422
# Server starts, API responds with status
curl http://localhost:8422/api/status
```

Closes #231